### PR TITLE
Use the getLoadValue() method instead

### DIFF
--- a/formwidgets/Price.php
+++ b/formwidgets/Price.php
@@ -84,6 +84,6 @@ class Price extends FormWidgetBase
      */
     public function getPriceValue($currency)
     {
-        return $this->model->{$this->fieldName}[$currency] ?? false;
+        return $this->getLoadValue()[$currency] ?? false;
     }
 }


### PR DESCRIPTION
In this case, the formwidget will also work for related data, i.e. if the data is not saved in the main model table, but in a pivot table.