### PR TITLE
Group by all selected columns

### DIFF
--- a/components/Product.php
+++ b/components/Product.php
@@ -335,7 +335,7 @@ class Product extends MallComponent
                                 )
                                 ->where('describable_type', Variant::class)
                                 ->whereNull('offline_mall_product_variants.deleted_at')
-                                ->select(DB::raw('describable_type, describable_id count(*) as matching_attributes'))
+                                ->select(DB::raw('describable_type, describable_id, count(*) as matching_attributes'))
                                 ->groupBy(['describable_id', 'describable_type'])
                                 ->having('matching_attributes', $values->count())
                                 ->first();


### PR DESCRIPTION
This prevents errors in MySQL 5.7+ with ``only_full_group_by``
Reference: https://stackoverflow.com/questions/34115174/error-related-to-only-full-group-by-when-executing-a-query-in-mysql