### PR TITLE
Add Default Order in Payment Methods Table

### DIFF
--- a/controllers/paymentmethods/config_reorder.yaml
+++ b/controllers/paymentmethods/config_reorder.yaml
@@ -1,5 +1,5 @@
 title: 'offline.mall::lang.titles.payment_methods.reorder'
 modelClass: OFFLINE\Mall\Models\PaymentMethod
-nameFrom: sort_order
+nameFrom: name
 toolbar:
     buttons: reorder_toolbar

--- a/updates/add_default_order_payment_methods.php
+++ b/updates/add_default_order_payment_methods.php
@@ -1,0 +1,23 @@
+<?php namespace OFFLINE\Mall\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class AddDefaultOrderPaymentMethods extends Migration
+{
+    public function up()
+    {
+        Schema::table('offline_mall_payment_methods', function($table)
+        {
+            $table->integer('sort_order')->default(1)->change();
+        });
+    }
+    
+    public function down()
+    {
+        Schema::table('offline_mall_payment_methods', function($table)
+        {
+            $table->integer('sort_order')->default(null)->change();
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -38,4 +38,5 @@
     - create_offline_mall_customer_group_prices.php
     - allow_non_unique_emails_for_rainlab_user.php
     - add_customer_group_id_to_rainlab_users.php
+    - add_default_order_payment_methods.php
     - database_seeder.php


### PR DESCRIPTION
fix for: Adding a new payment is not working due to a missing default value for `sort_order `field in table
and display Payment Method name instead of the sort id