### PR TITLE
Fix #125 (doubled escaping)

### DIFF
--- a/components/product/currentprice.htm
+++ b/components/product/currentprice.htm
@@ -1,1 +1,1 @@
-{{ price }}
+{{ price | raw }}

--- a/components/product/price.htm
+++ b/components/product/price.htm
@@ -3,9 +3,9 @@
 {% if price.official or item.oldPrice().integer %}
     <div class="mall-product__old-price">
         {% if price.official %}
-            {{ price.official.string }}
+            {{ price.official.string | raw }}
         {% else %}
-            {{ item.oldPrice().string }}
+            {{ item.oldPrice().string | raw }}
         {% endif %}
     </div>
 {% endif %}

--- a/components/products/item.htm
+++ b/components/products/item.htm
@@ -11,7 +11,7 @@
                 {% set price = item.price() %}
                 <div class="mall-products-item__price
                     {{ price.isCustomerSpecific ? 'mall-products-item__price--special' }}">
-                    {{ price.string }}
+                    {{ price.string | raw }}
                 </div>
             </div>
             <div class="mall-products-item__info-secondary">
@@ -20,9 +20,9 @@
                 </div>
                 <div class="mall-products-item__old-price">
                     {% if price.official %}
-                        {{ price.official.string }}
+                        {{ price.official.string | raw }}
                     {% else %}
-                        {{ item.oldPrice.count > 0 ? item.oldPrice().string }}
+                        {{ item.oldPrice.count > 0 ? item.oldPrice().string | raw }}
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
This fixes the escaping of the already by twig converted chars.

Not sure if it is safe to allow raw markup there, but I cannot see any potential dangerous scenarios...