### PR TITLE
Show properties html-tag only on variant method

### DIFF
--- a/components/product/cart.htm
+++ b/components/product/cart.htm
@@ -13,7 +13,7 @@
     </div>
 {% endif %}
 
-{% if props.count > 0 %}
+{% if props.count > 0 and item.inventory_management_method == 'variant' %}
     <div class="mall-product__variant-properties">
         {% partial __SELF__ ~ '::properties' props=props %}
     </div>


### PR DESCRIPTION
Only show the properties html-tag if the right inventory management method is selected.