### PR TITLE
Fix getAddressOptions return type

### DIFF
--- a/components/AddressForm.php
+++ b/components/AddressForm.php
@@ -87,7 +87,7 @@ class AddressForm extends MallComponent
      */
     public function getAddressOptions()
     {
-        return Address::get()->pluck('name', 'id');
+        return Address::get()->pluck('name', 'id')->toArray();
     }
 
     /**


### PR DESCRIPTION
When clicking on Form Addresses component, it throws the following error:

"substr() expects parameter 1 to be string, array given" on line 469 of /Users/marcomessa/dev/satemac/vendor/laravel/framework/src/Illuminate/Support/Str.php"

I edited AddressForm::getAddressOptions() to make it return an array.