### PR TITLE
Order by prices in FLOAT and not in VARCHAR

### DIFF
--- a/classes/index/mysql/MySQL.php
+++ b/classes/index/mysql/MySQL.php
@@ -256,7 +256,7 @@ class MySQL implements Index
             $field = $parts[0];
             array_shift($parts);
             $nested = implode('.', $parts);
-            $db->orderByRaw('JSON_EXTRACT(' . \DB::raw($field) . ', ?) ' . $order->direction(),
+            $db->orderByRaw('CAST(JSON_EXTRACT(' . \DB::raw($field) . ', ?) AS Float) ' . $order->direction(),
                 ['$.' . '"' . $nested . '"']
             );
         } else {


### PR DESCRIPTION
Result without casting in float :
12000000
1500000
200
3000

And with casting in float :
200
3000
1500000
12000000

I tested all the sorting method and it seems that only the prices enter in this code part, but maybe it needs a condition more than "if (str_contains($order->property(), '.')"?