### PR TITLE
WIP: Add Discount events

### DIFF
--- a/classes/cart/DiscountApplier.php
+++ b/classes/cart/DiscountApplier.php
@@ -2,6 +2,7 @@
 
 namespace OFFLINE\Mall\Classes\Cart;
 
+use Event;
 use Illuminate\Support\Collection;
 use OFFLINE\Mall\Classes\Totals\TotalsCalculatorInput;
 use OFFLINE\Mall\Classes\Utils\Money;
@@ -111,6 +112,10 @@ class DiscountApplier
 
         if ($discount->trigger === 'product' && $this->productIsInCart($discount->product_id)) {
             return true;
+        }
+
+        if ($discount->hasCustomTrigger()) {
+            return in_array(true, Event::fire('offline.mall.discounts.customTrigger', [$this, $discount]));
         }
 
         return $discount->trigger === 'code';

--- a/classes/totals/ShippingTotal.php
+++ b/classes/totals/ShippingTotal.php
@@ -156,7 +156,7 @@ class ShippingTotal implements \JsonSerializable
 
     private function applyDiscounts(int $price): ?float
     {
-        $discounts = Discount::whereIn('trigger', ['total', 'product'])
+        $discounts = Discount::whereIn('trigger', array_merge(['total', 'product'], array_keys(Discount::getCustomTriggerOptions(static::class))))
             ->where('type', 'shipping')
             ->where(function ($q) {
                 $q->whereNull('valid_from')

--- a/classes/totals/TotalsCalculator.php
+++ b/classes/totals/TotalsCalculator.php
@@ -3,6 +3,7 @@
 namespace OFFLINE\Mall\Classes\Totals;
 
 use Carbon\Carbon;
+use Event;
 use Illuminate\Support\Collection;
 use OFFLINE\Mall\Classes\Cart\DiscountApplier;
 use OFFLINE\Mall\Models\CartProduct;
@@ -265,7 +266,7 @@ class TotalsCalculator
      */
     protected function applyTotalDiscounts($total): ?float
     {
-        $nonCodeTriggers = Discount::whereIn('trigger', ['total', 'product'])
+        $nonCodeTriggers = Discount::whereIn('trigger', array_merge(['total', 'product'], array_keys(Discount::getCustomTriggerOptions(static::class))))
             ->where(function ($q) {
                 $q->whereNull('valid_from')
                     ->orWhere('valid_from', '<=', Carbon::now());

--- a/models/Discount.php
+++ b/models/Discount.php
@@ -1,5 +1,6 @@
 <?php namespace OFFLINE\Mall\Models;
 
+use Event;
 use Model;
 use October\Rain\Database\Traits\Nullable;
 use October\Rain\Database\Traits\Validation;
@@ -93,7 +94,32 @@ class Discount extends Model
 
     public function getTriggerOptions()
     {
-        return trans('offline.mall::lang.discounts.triggers');
+        return array_merge(trans('offline.mall::lang.discounts.triggers'), Discount::getCustomTriggerOptions());
+    }
+
+    public static function getCustomTriggerOptions($totalsClass = null)
+    {
+        $triggers = [];
+        $customTriggerLists = Event::fire('offline.mall.discounts.extendTriggerOptions', [$totalsClass]);
+
+        if (is_array($customTriggerLists)) {
+            foreach ($customTriggerLists as $customTriggerList) {
+                if (!is_array($customTriggerList)) {
+                    continue;
+                }
+
+                foreach ($customTriggerList as $triggerCode => $triggerName) {
+                    $triggers[$triggerCode] = $triggerName;
+                }
+            }
+        }
+
+        return $triggers;
+    }
+
+    public function hasCustomTrigger()
+    {
+        return in_array($this->trigger, array_keys($this->getCustomTriggerOptions()));
     }
 
     public function amount($currency = null)


### PR DESCRIPTION
Add discount events to be able to extend discount logic. As described in #375.

_This is a work in progress, so please help me find the right solution!_

**Being able to extend discount logic**
- [x] Extend when a discount is applied
- [ ] Extend how a discount is applied

**Extend when a discount is applied**
With my current solution we can extend triggers like this:
```
Event::listen('offline.mall.discounts.extendTriggerOptions', function ($totalsClass) {
    $triggers = [];

    if (!$totalsClass || $totalsClass == TotalsCalculator::class) {
        $triggers['custom_trigger'] = 'Custom trigger';
    }

    return $triggers;
});

Discount::extend(function ($model) {
    $rules = $model->rules;
    $rules['trigger'] = $rules['trigger'] . ',custom_trigger';
    $model->rules = $rules;
});

Event::listen('offline.mall.discounts.customTrigger', function ($discountApplier, $discount) {
    if ($discount->trigger != 'custom_trigger') {
        return;
    }

    // Add custom trigger conditions and return if triggered or not
    return true;
});
```

**Extend how a discount is applied**
For this I want to extend the discount types almost the same way as extending the triggers. WIP