### PR TITLE
MySQL cast sort_orders to unsigned

### DIFF
--- a/classes/index/mysql/MySQL.php
+++ b/classes/index/mysql/MySQL.php
@@ -29,7 +29,7 @@ class MySQL implements Index
      */
     public $columnCasts = [
         'prices'      => 'float',
-        'sort_orders' => 'int',
+        'sort_orders' => 'unsigned',
     ];
 
     public function __construct()


### PR DESCRIPTION
Thanks for this project ;) 
This PR fix a bug I have introduced in #387 sorry for that.

Cast to int is not supported on MySQL 5.7 (only supported by MariaDB)
https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_cast
