### PR TITLE
Make customer profile form extendable

### DIFF
--- a/components/CustomerProfile.php
+++ b/components/CustomerProfile.php
@@ -2,6 +2,7 @@
 
 use Auth;
 use DB;
+use Event;
 use October\Rain\Exception\ValidationException;
 use October\Rain\Support\Facades\Flash;
 use OFFLINE\Mall\Classes\Customer\SignUpHandler;
@@ -98,6 +99,8 @@ class CustomerProfile extends MallComponent
             $this->user->save();
             $this->user->customer->save();
         });
+
+        Event::fire('mall.customer.afterUpdate', [$this->user]);
 
         // Re-authenticate the user with his new credentials
         Auth::login($this->user);


### PR DESCRIPTION
All the shop is very extendable except this profile edit form that we are not able to extend properly to save additional fields we will like to add to the user profile.

This PR add event `mall.customer.afterUpdate` like in DefaultSignInHandler::signUp
https://github.com/OFFLINE-GmbH/oc-mall-plugin/blob/develop/classes/customer/DefaultSignUpHandler.php#L92

But if instead/in addition of this you will be ok to add a `$this->user->fill($data)` in  [components/CustomerProfile.php#L88-L99](https://github.com/OFFLINE-GmbH/oc-mall-plugin/blob/develop/components/CustomerProfile.php#L88-L99) and in [DefaultSignUpHandler::signUp](https://github.com/OFFLINE-GmbH/oc-mall-plugin/blob/develop/classes/customer/DefaultSignUpHandler.php#L48) this should be very usefull