### PR TITLE
order_state column of Order model can't be sortable

### DIFF
--- a/models/order/columns.yaml
+++ b/models/order/columns.yaml
@@ -36,7 +36,7 @@ columns:
         label: 'offline.mall::lang.order.status'
         type: partial
         path: $/offline/mall/models/order/_order_state.htm
-        sortable: true
+        sortable: false
         searchable: false
     payment_state:
         label: 'offline.mall::lang.order.payment_status'


### PR DESCRIPTION
This avoid the PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'order_state' in 'order clause' when trying to sort  it