### PR TITLE
only load pages that have the asked component in GeneralSettings

### DIFF
--- a/models/GeneralSettings.php
+++ b/models/GeneralSettings.php
@@ -5,6 +5,7 @@ namespace OFFLINE\Mall\Models;
 use Cms\Classes\Page;
 use Illuminate\Support\Facades\Cache;
 use Model;
+use Cms\Classes\Theme;
 use Session;
 
 class GeneralSettings extends Model
@@ -18,8 +19,52 @@ class GeneralSettings extends Model
         Cache::forget('offline_mall.mysql.index.driver');
     }
 
-    public function getPageOptions()
+    public function getPagesByComponent($component)
     {
-        return Page::sortBy('baseFileName')->lists('title', 'baseFileName');
+        $theme = Theme::getActiveTheme();
+        $pages = Page::listInTheme($theme, true);
+        
+        $cmsPages = [];
+        
+        foreach ($pages as $page) {
+            if (!$page->hasComponent($component)) {
+                continue;
+            }
+            $cmsPages[$page->baseFileName] = $page->title;
+        }
+
+        return $cmsPages;
     }
+
+    public function getProductPageOptions()
+    {
+        return $this->getPagesByComponent('product');
+    }
+
+    public function getCategoryPageOptions()
+    {
+        return $this->getPagesByComponent('products');
+    }
+
+    public function getAddressPageOptions()
+    {
+        return $this->getPagesByComponent('addressForm');
+    }
+
+    public function getCheckoutPageOptions()
+    {
+        return $this->getPagesByComponent('checkout');
+    }
+
+    public function getAccountPageOptions()
+    {
+        return $this->getPagesByComponent('myAccount');
+    }
+
+    public function getCartPageOptions()
+    {
+        return $this->getPagesByComponent('cart');
+    }
+
+
 }

--- a/models/settings/fields_general.yaml
+++ b/models/settings/fields_general.yaml
@@ -32,42 +32,36 @@ fields:
         label: offline.mall::lang.general_settings.product_page
         span: left
         type: dropdown
-        options: getPageOptions
         comment: offline.mall::lang.general_settings.product_page_comment
 
     category_page:
         label: offline.mall::lang.general_settings.category_page
         span: right
         type: dropdown
-        options: getPageOptions
         comment: offline.mall::lang.general_settings.category_page_comment
 
     address_page:
         label: offline.mall::lang.general_settings.address_page
         span: left
         type: dropdown
-        options: getPageOptions
         comment: offline.mall::lang.general_settings.address_page_comment
 
     checkout_page:
         label: offline.mall::lang.general_settings.checkout_page
         span: right
         type: dropdown
-        options: getPageOptions
         comment: offline.mall::lang.general_settings.checkout_page_comment
 
     account_page:
         label: offline.mall::lang.general_settings.account_page
         span: left
         type: dropdown
-        options: getPageOptions
         comment: offline.mall::lang.general_settings.account_page_comment
 
     cart_page:
         label: offline.mall::lang.general_settings.cart_page
         span: right
         type: dropdown
-        options: getPageOptions
         comment: offline.mall::lang.general_settings.cart_page_comment
 
     customizations:


### PR DESCRIPTION
The `GeneralSettings` model has 6 dropdowns that need to be pointed at the correct page with a specified component. The old approach loads all pages listed in the CMS, now only the pages are displayed that have the actual component present.