### PR TITLE
Use hashed ID for variant URLs

### DIFF
--- a/classes/feeds/GoogleMerchantFeed.php
+++ b/classes/feeds/GoogleMerchantFeed.php
@@ -68,7 +68,7 @@ class GoogleMerchantFeed
 
         $url = Page::url($this->productPage, [
             'slug'    => $item->slug,
-            'variant' => $item->variantId,
+            'variant' => $item->variantHashId,
         ]);
 
         $description = \Html::strip($item->description ?: $item->description_short);


### PR DESCRIPTION
This fixes incorrect URLs for variants in the Google Merchant Feed.