### PR TITLE
Added support for “google_product_category”

### DIFF
--- a/classes/feeds/GoogleMerchantFeed.php
+++ b/classes/feeds/GoogleMerchantFeed.php
@@ -96,6 +96,7 @@ class GoogleMerchantFeed
             $entry->setAvailability(Availability::OUT_OF_STOCK);
         }
 
+        $this->handleProductCategory($item, $entry);
         $this->handleIdentifier($item, $entry);
 
         $this->feed->addProduct($entry);
@@ -109,6 +110,27 @@ class GoogleMerchantFeed
         if ($this->locale === null && $this->rainlabTranslateInstalled()) {
             $this->locale = Translator::instance()->getDefaultLocale();
         }
+    }
+
+    /**
+     * Handle Product Category attribute.
+     *
+     * @param         $item
+     * @param Product $entry
+     */
+    private function handleProductCategory($item, Product $entry): void
+    {
+        if ($item->inventory_management_method === 'variant') {
+            if ($item->product->categories) {
+                $category = $item->product->categories()->first();
+            }
+        } else {
+            if ($item->categories) {
+                $category = $item->categories()->first();
+            }
+        }
+
+        $entry->setGoogleCategory($category->google_product_category_id);
     }
 
     /**

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -447,6 +447,8 @@
         'name'                              => 'Name',
         'code'                              => 'Code',
         'code_comment'                      => 'Dieser Code kann im Frontend zur Identifikation der Kategorie genutzt werden.',
+        'google_product_category_id'        => 'Google Produktkategorie ID',
+        'google_product_category_id_comment'=> 'Für mehr Infos siehe https://support.google.com/merchants/answer/6324436',
         'parent'                            => 'Elternelement',
         'no_parent'                         => 'Kein Elternelement',
         'inherit_property_groups'           => 'Übernehme Eigenschaften von Elternkategorie',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -448,6 +448,8 @@
         'name'                              => 'Name',
         'code'                              => 'Code',
         'code_comment'                      => 'This code can be used to identify this category in your frontend partials.',
+        'google_product_category_id'        => 'Google Product Category ID',
+        'google_product_category_id_comment'=> 'For more information, see https://support.google.com/merchants/answer/6324436',
         'parent'                            => 'Parent',
         'no_parent'                         => 'No parent',
         'inherit_property_groups'           => 'Inherit properties of parent category',

--- a/models/Category.php
+++ b/models/Category.php
@@ -71,6 +71,7 @@ class Category extends Model
         'inherit_property_groups',
         'inherit_review_categories',
         'sort_order',
+        'google_product_category_id',
     ];
     public $casts = [
         'inherit_property_groups'   => 'boolean',

--- a/models/category/fields.yaml
+++ b/models/category/fields.yaml
@@ -34,6 +34,11 @@ fields:
         comment: 'offline.mall::lang.category.code_comment'
         span: left
         type: text
+    google_product_category_id:
+            label: 'offline.mall::lang.category.google_product_category_id'
+            comment: 'offline.mall::lang.category.google_product_category_id_comment'
+            span: left
+            type: number
 tabs:
     fields:
         inherit_property_groups:

--- a/updates/add_google_product_category_id_column_to_categories_table.php
+++ b/updates/add_google_product_category_id_column_to_categories_table.php
@@ -1,0 +1,22 @@
+<?php namespace OFFLINE\Mall\Updates;
+
+use October\Rain\Database\Schema\Blueprint;
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class AddGoogleProductCategoryIdColumnToCategoriesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('offline_mall_categories', function (Blueprint $table) {
+            $table->integer('google_product_category_id')->after('sort_order')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('offline_mall_categories', function (Blueprint $table) {
+            $table->dropColumn(['google_product_category_id']);
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -280,3 +280,6 @@
     - Bugfix release
 1.10.2:
     - "!!! Do not update until version 1.11 is released. There is a bug in RainLab.Translate because of which translations won't be loaded correctly. Also do not update RainLab.Translate until this bug is fixed: https://github.com/rainlab/translate-plugin/issues/539. We will release a new version as soon as everything is back in order."
+1.11.0:
+    - Added support for Google Product Category ID
+    - add_google_product_category_id_column_to_categories_table.php


### PR DESCRIPTION
I needed an additional field "google_product_category" for my shop to render in the Google Merchant Feed, so I added a new form field in the backend.

More information about this can be found here: https://support.google.com/merchants/answer/6324436?hl=en

Probably needs some polishing as I don't have much experience in developing October plugins.