### PR TITLE
Update config_list.yaml

### DIFF
--- a/controllers/orders/config_list.yaml
+++ b/controllers/orders/config_list.yaml
@@ -8,7 +8,7 @@ showSetup: true
 showCheckboxes: false
 defaultSort:
     column: created_at
-    direction: asc
+    direction: desc
 toolbar:
     buttons: list_toolbar
     search:


### PR DESCRIPTION
I propose to sort the list of orders by date in descending order. It seems to me that it is more convenient for the manager to immediately see the latest orders, rather than outdated ones.