### PR TITLE
Updating PaymentLog model

### DIFF
--- a/models/PaymentLog.php
+++ b/models/PaymentLog.php
@@ -17,6 +17,8 @@ class PaymentLog extends Model
         'payment_method' => 'required',
     ];
 
+    public $belongsTo = ['order' => Order::class];
+
     public static function boot()
     {
         parent::boot();

--- a/models/paymentlog/columns.yaml
+++ b/models/paymentlog/columns.yaml
@@ -4,11 +4,13 @@ columns:
         type: number
         sortable: true
         invisible: true
-    order_id:
+    order:
         label: 'offline.mall::lang.order.order_number'
+        relation: order
         type: number
         searchable: true
         sortable: true
+        select: order_number
     failed:
         label: 'offline.mall::lang.order.status'
         type: partial


### PR DESCRIPTION
Instead of order_id, order_number is now displayed in the list of payment logs. This solves the problem of mismatch of order numbers in the list of orders and payment logs if the id and order_number are different in the Order model (for some reason, I had an out of sync id and order_id.).