### PR TITLE
Fix bad SQL in morph conditions

### DIFF
--- a/models/Discount.php
+++ b/models/Discount.php
@@ -37,9 +37,9 @@ class Discount extends Model
         'number_of_usages' => 'integer',
     ];
     public $morphMany = [
-        'shipping_prices' => [Price::class, 'name' => 'priceable', 'conditions' => 'field = "shipping_prices"'],
-        'amounts'         => [Price::class, 'name' => 'priceable', 'conditions' => 'field = "amounts"'],
-        'totals_to_reach' => [Price::class, 'name' => 'priceable', 'conditions' => 'field = "totals_to_reach"'],
+        'shipping_prices' => [Price::class, 'name' => 'priceable', 'conditions' => "field = 'shipping_prices'"],
+        'amounts'         => [Price::class, 'name' => 'priceable', 'conditions' => "field = 'amounts'"],
+        'totals_to_reach' => [Price::class, 'name' => 'priceable', 'conditions' => "field = 'totals_to_reach'"],
     ];
     public $fillable = [
         'name',

--- a/models/ShippingMethod.php
+++ b/models/ShippingMethod.php
@@ -51,12 +51,12 @@ class ShippingMethod extends Model
         'available_below_totals' => [
             Price::class,
             'name'       => 'priceable',
-            'conditions' => 'price_category_id is null and field = "available_below_totals"',
+            'conditions' => "price_category_id is null and field = 'available_below_totals'",
         ],
         'available_above_totals' => [
             Price::class,
             'name'       => 'priceable',
-            'conditions' => 'price_category_id is null and field = "available_above_totals"',
+            'conditions' => "price_category_id is null and field = 'available_above_totals'",
         ],
     ];
     public $hasMany = [


### PR DESCRIPTION
Double quotes is used for escaping identifiers, single quotes is for strings.

Fixes #498