### PR TITLE
prefix Request:: and Flash:: with slash for the global namespace.

### DIFF
--- a/classes/downloads/VirtualProductFileDownload.php
+++ b/classes/downloads/VirtualProductFileDownload.php
@@ -89,8 +89,8 @@ class VirtualProductFileDownload
      */
     protected function redirectToLogin()
     {
-        Session::put('mall.login.redirect', Request::url());
-        Flash::warning(trans('offline.mall::frontend.session.login_required'));
+        Session::put('mall.login.redirect', \Request::url());
+        \Flash::warning(trans('offline.mall::frontend.session.login_required'));
 
         $url = Page::url(GeneralSettings::get('account_page'));
 


### PR DESCRIPTION
This fixes fatal errors when a user tries to download virtual products but is not logged in

![image](https://user-images.githubusercontent.com/1073497/81411262-6c5b1900-9142-11ea-8e81-bcd59747ec8f.png)

![image](https://user-images.githubusercontent.com/1073497/81411302-7c72f880-9142-11ea-96f6-2489c7cc4766.png)
