### PR TITLE
Extend product price table config

### DIFF
--- a/classes/traits/ProductPriceTable.php
+++ b/classes/traits/ProductPriceTable.php
@@ -18,6 +18,8 @@ use OFFLINE\Mall\Models\Variant;
 
 trait ProductPriceTable
 {
+    public $productPriceTableConfig = 'config_table.yaml';
+    
     public function onLoadPriceTable()
     {
         return $this->makePartial('price_table_modal', ['widget' => $this->vars['pricetable']]);
@@ -25,7 +27,7 @@ trait ProductPriceTable
 
     protected function preparePriceTable()
     {
-        $config = $this->makeConfig('config_table.yaml');
+        $config = $this->makeConfig($this->productPriceTableConfig);
 
         $additionalPriceCategories = PriceCategory::orderBy('sort_order', 'ASC')->get();
         $additionalPriceCategories->each(function (PriceCategory $category) use ($config) {

--- a/classes/traits/ProductPriceTable.php
+++ b/classes/traits/ProductPriceTable.php
@@ -17,9 +17,7 @@ use OFFLINE\Mall\Models\ProductPrice;
 use OFFLINE\Mall\Models\Variant;
 
 trait ProductPriceTable
-{
-    public $productPriceTableConfig = 'config_table.yaml';
-    
+{   
     public function onLoadPriceTable()
     {
         return $this->makePartial('price_table_modal', ['widget' => $this->vars['pricetable']]);

--- a/classes/traits/ProductPriceTable.php
+++ b/classes/traits/ProductPriceTable.php
@@ -17,7 +17,7 @@ use OFFLINE\Mall\Models\ProductPrice;
 use OFFLINE\Mall\Models\Variant;
 
 trait ProductPriceTable
-{   
+{
     public function onLoadPriceTable()
     {
         return $this->makePartial('price_table_modal', ['widget' => $this->vars['pricetable']]);

--- a/controllers/Products.php
+++ b/controllers/Products.php
@@ -33,6 +33,7 @@ class Products extends Controller
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
     public $relationConfig = 'config_relation.yaml';
+    public $productPriceTableConfig = 'config_table.yaml';
     public $requiredPermissions = [
         'offline.mall.manage_products',
     ];


### PR DESCRIPTION
I've been working on a project that requires to add some info to the product price table. With these changes, one could extend the config by overriding the `offline/mall/controllers/products/config_table.yaml` file in this way:

in `MyVendor\MyPlugin\Plugin.php`:
``` php
public function boot()
{
    \OFFLINE\Mall\Controllers\Products::extend(function ($controller) {
        $controller->productPriceTableConfig = '$/myvendor/myplugin/controllers/products/config_table.yaml';
    });
}
```

And in `myvendor/myplugin/controllers/products/config_table.yaml` one could do something like:
```yaml
dataSource: client
keyFrom: id
recordsPerPage: false
adding: false
deleting: false
searching: false
alias: pricetable
columns:
    name:
        title: offline.mall::lang.common.product_or_variant
        readOnly: true
    stock:
        title: offline.mall::lang.product.stock
    extra_field:
        title: 'Extra Field name'
    price:
        title: offline.mall::lang.product.price
```