### PR TITLE
Bugfix script error in Stripe partial

### DIFF
--- a/components/paymentmethodselector/gateways/stripe.htm
+++ b/components/paymentmethodselector/gateways/stripe.htm
@@ -8,6 +8,7 @@
     <input type="hidden" name="payment_data[token]" value="" id="stripe-token">
 </div>
 
+{% put scripts %}
 <script>
     $(function () {
 
@@ -64,3 +65,4 @@
         }
     });
 </script>
+{% endput %}


### PR DESCRIPTION
Avoids getting an error message if the jQuery script is not yet loaded.
Pushes the scripts on the page into the `{% scripts %}` OctoberCms placeholder.