### PR TITLE
Sorting through sort orders

### DIFF
--- a/controllers/currencies/config_list.yaml
+++ b/controllers/currencies/config_list.yaml
@@ -6,6 +6,9 @@ noRecordsMessage: 'backend::lang.list.no_records'
 recordsPerPage: 20
 showSetup: true
 showCheckboxes: true
+defaultSort:
+    column: sort_order
+    direction: asc
 toolbar:
     buttons: list_toolbar
     search:

--- a/controllers/paymentmethods/config_list.yaml
+++ b/controllers/paymentmethods/config_list.yaml
@@ -7,6 +7,9 @@ recordsPerPage: 20
 showSetup: true
 showCheckboxes: true
 showSorting: 1
+defaultSort:
+    column: sort_order
+    direction: asc
 toolbar:
     buttons: list_toolbar
     search:

--- a/controllers/pricecategories/config_list.yaml
+++ b/controllers/pricecategories/config_list.yaml
@@ -6,6 +6,9 @@ noRecordsMessage: 'backend::lang.list.no_records'
 recordsPerPage: 20
 showSetup: true
 showCheckboxes: true
+defaultSort:
+    column: sort_order
+    direction: asc
 toolbar:
     buttons: list_toolbar
     search:

--- a/controllers/propertygroups/config_list.yaml
+++ b/controllers/propertygroups/config_list.yaml
@@ -7,7 +7,7 @@ recordsPerPage: 20
 showSetup: true
 showCheckboxes: true
 defaultSort:
-    column: name
+    column: sort_order
     direction: asc
 toolbar:
     buttons: list_toolbar

--- a/controllers/shippingmethods/config_list.yaml
+++ b/controllers/shippingmethods/config_list.yaml
@@ -6,6 +6,9 @@ noRecordsMessage: 'backend::lang.list.no_records'
 recordsPerPage: 20
 showSetup: true
 showCheckboxes: true
+defaultSort:
+    column: sort_order
+    direction: asc
 toolbar:
     buttons: list_toolbar
     search:

--- a/models/brand/columns.yaml
+++ b/models/brand/columns.yaml
@@ -1,4 +1,10 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     name:
         label: 'offline.mall::lang.common.name'
         type: text
@@ -14,12 +20,6 @@ columns:
         type: text
         searchable: true
         sortable: true
-    sort_order:
-        label: 'offline.mall::lang.common.sort_order'
-        type: number
-        searchable: false
-        sortable: true
-        invisible: true
     created_at:
         label: 'offline.mall::lang.common.created_at'
         type: datetime

--- a/models/currency/columns.yaml
+++ b/models/currency/columns.yaml
@@ -1,8 +1,10 @@
 columns:
-    code:
-        label: 'offline.mall::lang.currency_settings.currency_code'
-        type: text
-        searchable: true
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     code:
         label: 'offline.mall::lang.currency_settings.currency_code'
         type: text

--- a/models/notification/columns.yaml
+++ b/models/notification/columns.yaml
@@ -1,4 +1,8 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        invisible: true
     enabled:
         label:  'offline.mall::lang.notifications.enabled'
         type: partial
@@ -25,10 +29,6 @@ columns:
         type: text
         searchable: true
         sortable: true
-    sort_order:
-        label: 'offline.mall::lang.common.sort_order'
-        type: number
-        invisible: true
     created_at:
         label: 'offline.mall::lang.common.created_at'
         type: datetime

--- a/models/orderstate/columns.yaml
+++ b/models/orderstate/columns.yaml
@@ -1,4 +1,10 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     name:
         label: 'offline.mall::lang.order_states.name'
         type: partial
@@ -21,8 +27,4 @@ columns:
     deleted_at:
         label: 'offline.mall::lang.common.deleted_at'
         type: datetime
-        invisible: true
-    sort_order:
-        label: 'offline.mall::lang.common.sort_order'
-        type: number
         invisible: true

--- a/models/paymentmethod/columns.yaml
+++ b/models/paymentmethod/columns.yaml
@@ -1,4 +1,10 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     name:
         label: 'offline.mall::lang.common.name'
         type: text

--- a/models/pricecategory/columns.yaml
+++ b/models/pricecategory/columns.yaml
@@ -1,4 +1,10 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     name:
         label: 'offline.mall::lang.common.name'
         type: text

--- a/models/propertygroup/columns.yaml
+++ b/models/propertygroup/columns.yaml
@@ -1,4 +1,10 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     name:
         label: 'offline.mall::lang.common.name'
         type: text

--- a/models/shippingmethod/columns.yaml
+++ b/models/shippingmethod/columns.yaml
@@ -1,4 +1,10 @@
 columns:
+    sort_order:
+        label: 'offline.mall::lang.common.sort_order'
+        type: number
+        searchable: false
+        sortable: true
+        invisible: true
     name:
         label: 'offline.mall::lang.common.name'
         type: text


### PR DESCRIPTION
Every backend controller that lists models with `sort_order` attribute gets invisible column and `defaultSort`: #518 