### PR TITLE
Event after order create and before cart delete

### DIFF
--- a/models/Order.php
+++ b/models/Order.php
@@ -191,6 +191,8 @@ class Order extends Model
             $order->attributes['total_post_taxes']          = $order->round($totals->totalPostTaxes());
             $order->total_weight                            = $order->round($totals->weightTotal());
             $order->save();
+            
+            Event::fire('mall.order.beforeCreate', [$order, $cart]);
 
             $cart
                 ->loadMissing(['products.product.brand'])

--- a/models/Order.php
+++ b/models/Order.php
@@ -192,7 +192,7 @@ class Order extends Model
             $order->total_weight                            = $order->round($totals->weightTotal());
             $order->save();
             
-            Event::fire('mall.order.beforeCreate', [$order, $cart]);
+            Event::fire('mall.order.afterCreate', [$order, $cart]);
 
             $cart
                 ->loadMissing(['products.product.brand'])


### PR DESCRIPTION
I've a situation where i'd like to collect an extra field (delivery date), from the cart and assign it to the order upon creation. Since the order creation is within a transaction, and the cart gets deleted within the transaction, I can't find a way to transfer elements from one to the other.

Conceptually, I'm requesting an event to be fired within the transaction that passes both the recently created order and the soon to be deleted cart. This would allow adding any number of extra fields to a cart and manipulating the resulting order how the developer sees fit. 

In any Plugin.php, one would:

```php
Event::listen('mall.order.afterCreate', function($order, $cart){
    $order->extraField = $cart->extraField;
    
    // or
    
    $order->existingAttribute = $cart->newManipulatingMethod();
});
```
You get the idea.