### PR TITLE
 add default value empty string in Request::header

### DIFF
--- a/controllers/Products.php
+++ b/controllers/Products.php
@@ -54,7 +54,7 @@ class Products extends Controller
             // existence and doesn't inherit the parent product's data if it exists.
             session()->flash('mall.variants.disable-inheritance');
 
-            if (str_contains(\Request::header('X-OCTOBER-REQUEST-HANDLER'), 'PriceTable')) {
+            if (str_contains(\Request::header('X-OCTOBER-REQUEST-HANDLER',''), 'PriceTable')) {
                 $this->preparePriceTable();
             }
         }


### PR DESCRIPTION
added default value empty string in Request::header in \Request::header('X-OCTOBER-REQUEST-HANDLER','') because 
str_contains() accept strict type "string".
 \Request::header('X-OCTOBER-REQUEST-HANDLER') return null, if header X-OCTOBER-REQUEST-HANDLER is empty.
When you have declare(strict_types=1); it cause to fatal error.