### PR TITLE
Fixed customer user backend link in order scoreboard

### DIFF
--- a/controllers/orders/_detail_scoreboard.htm
+++ b/controllers/orders/_detail_scoreboard.htm
@@ -6,7 +6,7 @@
 
 <div class="scoreboard-item title-value">
     <h4><?= e(trans('offline.mall::lang.order.customer')) ?></h4>
-    <p><a href="<?= $customerPreview . '/' . e($order['customer_id']); ?>">
+    <p><a href="<?= $customerPreview . '/' . e($order->customer->user_id); ?>">
         <?= e($order['billing_address']['name']) ?>
     </a></p>
     <p class="description">


### PR DESCRIPTION
Invalid link uncovered itself while adding Mall to OctoberCMS installation with existing RainLab.Users that weren't Mall.Customers, @tobias-kuendig 