### PR TITLE
Allows for event listen execution sorting

### DIFF
--- a/classes/registration/BootExtensions.php
+++ b/classes/registration/BootExtensions.php
@@ -101,7 +101,7 @@ trait BootExtensions
                     'permissions' => ['rainlab.users.*', 'offline.mall.manage_customer_addresses'],
                 ],
             ]);
-        });
+        }, 5);
 
         // Add Customer Groups relation to RainLab.User form
         Event::listen('backend.form.extendFields', function (Form $widget) {
@@ -131,6 +131,6 @@ trait BootExtensions
                 //     'tab'   => 'offline.mall::lang.plugin.name',
                 // ],
             ]);
-        });
+        }, 5);
     }
 }


### PR DESCRIPTION
Thinking about extensibility, lowering the priority on the `backend.form.extendFields` or `backend.menu.extendItems` events would allow a third party plugin to control the execution order of colliding extension features. I've actually have had to do it in a personal fork in order to properly customize the user preview on Rainlab/User.