### PR TITLE
Removed colon

### DIFF
--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -192,7 +192,7 @@
 1.3.13:
     - Fixed payment log display in backend order list
 1.3.14:
-    - !!! This release does not contain any code updates. If you are using the mall demo theme make sure to patch the following two lines to prevent XSS attacks on your website: https://bit.ly/2Y4lUs3
+    - !!! This release does not contain any code updates. If you are using the mall demo theme make sure to patch the following two lines to prevent XSS attacks on your website https://bit.ly/2Y4lUs3
 1.3.15:
     - Added embeds repeater to Product model to add custom embed code (like videos)
     - add_embeds_column_to_products_table.php


### PR DESCRIPTION
Today I cannot fresh install oc-mall. After some struggle, I found that the colon in updates.yaml break installation process throwing this error:

In VersionManager.php line 565:
preg_match() expects parameter 2 to be string, array given 

Hope this help!