### PR TITLE
Event to extend index

### DIFF
--- a/classes/index/ProductEntry.php
+++ b/classes/index/ProductEntry.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use OFFLINE\Mall\Models\Currency;
 use OFFLINE\Mall\Models\CustomerGroup;
 use OFFLINE\Mall\Models\Product;
+use Event;
 
 class ProductEntry implements Entry
 {
@@ -35,7 +36,13 @@ class ProductEntry implements Entry
 
         $data['sort_orders'] = $product->getSortOrders();
 
-        $this->data = $data;
+        $result = Event::fire('mall.index.extendProduct', [$product]);
+
+        if ($result && is_array($result)) {
+            $this->data = call_user_func_array('array_merge', array_filter($result)) + $data;
+        } else {
+            $this->data = $data;
+        }
     }
 
     public function data(): array

--- a/classes/index/VariantEntry.php
+++ b/classes/index/VariantEntry.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use OFFLINE\Mall\Models\Currency;
 use OFFLINE\Mall\Models\CustomerGroup;
 use OFFLINE\Mall\Models\Variant;
+use Event;
 
 class VariantEntry implements Entry
 {
@@ -43,7 +44,13 @@ class VariantEntry implements Entry
             $data['brand'] = ['id' => $product->brand->id, 'slug' => $product->brand->slug];
         }
 
-        $this->data = $data;
+        $result = Event::fire('mall.index.extendVariant', [$product, $variant]);
+
+        if ($result && is_array($result)) {
+            $this->data = call_user_func_array('array_merge', array_filter($result)) + $data;
+        } else {
+            $this->data = $data;
+        }
     }
 
     public function data(): array


### PR DESCRIPTION
This is allows you to hook into the indexing process and add your custom data using event
Example usage:
```
        Event::listen('mall.index.extendProduct', function ($product) {
            return ["mycustomdata" => $product->destinations->pluck("id")];
        });

        Event::listen('mall.index.extendVariant', function ($product, $variant) {
            return ["mycustomdata" => $product->destinations->pluck("id")];
        });

```

Notice that you should also need to extend the mysql index and bind it to the service container.
```
        app()->bind(Index::class, function () {
            return new YourOwnExtendedMySQL();
        });
```

In you own mysql index override the `persist` method adding your custom data.


resolves #584 