### PR TITLE
enabled  svg and webp image formats to Payment and Shipping Methods

### DIFF
--- a/models/paymentmethod/fields.yaml
+++ b/models/paymentmethod/fields.yaml
@@ -44,6 +44,7 @@ tabs:
             label: 'offline.mall::lang.common.logo'
             oc.commentPosition: ''
             mode: image
+            fileTypes: jpg,jpeg,bmp,png,webp,gif,svg
             imageWidth: '200'
             imageHeight: '200'
             useCaption: 0

--- a/models/shippingmethod/fields.yaml
+++ b/models/shippingmethod/fields.yaml
@@ -40,6 +40,7 @@ tabs:
             label: 'offline.mall::lang.common.logo'
             oc.commentPosition: ''
             mode: image
+            fileTypes: jpg,jpeg,bmp,png,webp,gif,svg
             imageWidth: '150'
             useCaption: 0
             thumbOptions:


### PR DESCRIPTION
Adding svg to logo upload is handy and does not have security issues because it's used on <img src="">