### PR TITLE
sort properties when rendering the mall.propertyfields formwidget

### DIFF
--- a/formwidgets/PropertyFields.php
+++ b/formwidgets/PropertyFields.php
@@ -67,7 +67,7 @@ class PropertyFields extends FormWidgetBase
                 return $unknownIds->contains($property->id);
             });
 
-            $group->setRelation('properties', $properties);
+            $group->setRelation('properties', $properties->sortBy('sort_order'));
 
             return $group;
         });


### PR DESCRIPTION
Use the sort_order key when rendering the properties in the PropertyFields formwidget. 