### PR TITLE
Only show published variants in menus

### DIFF
--- a/models/Variant.php
+++ b/models/Variant.php
@@ -370,6 +370,9 @@ class Variant extends Model
 
         $items = self
             ::published()
+			->whereHas('product',function($query) {
+					$query->where('offline_mall_products.published', 1);
+				})
             ->with('product')
             ->get()
             ->map(function (self $variant) use ($cmsPage, $page, $url) {


### PR DESCRIPTION
Currently "[OFFLINE.Mall] All Shop Variants" type menu items show published variants only, which is correct. But they also show published variants of products which have not been published. This is incorrect. This fix aims to correct this by also filtering on the published property of the product related to each variant.