### PR TITLE
Checkout : Shipping before payment #303

### DIFF
--- a/components/Checkout.php
+++ b/components/Checkout.php
@@ -60,6 +60,12 @@ class Checkout extends MallComponent
      * @var array
      */
     public $dataLayer;
+    /**
+     * Backend setting whether shipping should be before payment.
+     *
+     * @var bool
+     */
+    public $shippingSelectionBeforePayment = false;
 
     /**
      * Component details.
@@ -157,6 +163,7 @@ class Checkout extends MallComponent
         $this->setVar('paymentMethod', PaymentMethod::find($cart->payment_method_id) ?? PaymentMethod::getDefault());
         $this->setVar('step', $this->property('step'));
         $this->setVar('accountPage', GeneralSettings::get('account_page'));
+        $this->setVar('shippingSelectionBeforePayment', GeneralSettings::get('shipping_selection_before_payment', false));	// Needed by themes
 
         if ($orderId = request()->get('order')) {
             $orderId = $this->decode($orderId);
@@ -183,7 +190,9 @@ class Checkout extends MallComponent
         // the payment method selection screen.
         $step = $this->property('step');
         if ( ! $step || ! array_key_exists($step, $this->getStepOptions())) {
-            $url = $this->stepUrl('payment');
+
+			$shippingBeforePayment = GeneralSettings::get('shipping_selection_before_payment', false);
+            $url = $this->stepUrl($shippingBeforePayment ? 'shipping' : 'payment');
 
             return redirect()->to($url);
         }

--- a/components/PaymentMethodSelector.php
+++ b/components/PaymentMethodSelector.php
@@ -9,6 +9,7 @@ use OFFLINE\Mall\Classes\Payments\PaymentGateway;
 use OFFLINE\Mall\Classes\Payments\PaymentService;
 use OFFLINE\Mall\Classes\Traits\HashIds;
 use OFFLINE\Mall\Models\Cart;
+use OFFLINE\Mall\Models\GeneralSettings;
 use OFFLINE\Mall\Models\CustomerPaymentMethod;
 use OFFLINE\Mall\Models\Order;
 use OFFLINE\Mall\Models\PaymentMethod;
@@ -65,6 +66,12 @@ class PaymentMethodSelector extends MallComponent
      * @var Order|Cart
      */
     public $workingOnModel;
+    /**
+     * Backend setting whether shipping should be before payment.
+     *
+     * @var bool
+     */
+    public $shippingSelectionBeforePayment = false;
 
     /**
      * Component details.
@@ -118,6 +125,7 @@ class PaymentMethodSelector extends MallComponent
         $this->setVar('methods', PaymentMethod::orderBy('sort_order', 'ASC')->get());
         $this->setVar('customerMethods', $this->getCustomerMethods());
         $this->setVar('activeMethod', $method);
+        $this->setVar('shippingSelectionBeforePayment', GeneralSettings::get('shipping_selection_before_payment', false));	// Needed by themes
 
         try {
             $paymentData = json_decode(decrypt(session()->get('mall.payment_method.data')), true);
@@ -284,7 +292,15 @@ class PaymentMethodSelector extends MallComponent
         // Just to prevent any data leakage we store payment information encrypted to the session.
         session()->put('mall.payment_method.data', encrypt(json_encode($data)));
 
-        $nextStep = request()->get('via') === 'confirm' ? 'confirm' : 'shipping';
+		$shippingBeforePayment = GeneralSettings::get('shipping_selection_before_payment', false);
+		if ($shippingBeforePayment) 
+		{
+			$nextStep = 'confirm';
+		}
+		else 
+		{
+			$nextStep = request()->get('via') === 'confirm' ? 'confirm' : 'shipping';
+		}
 
         $url = $this->getStepUrl($nextStep, 'payment');
 

--- a/lang/cs/lang.php
+++ b/lang/cs/lang.php
@@ -161,6 +161,8 @@
         'use_state_comment'          => 'Zákazník musí použít pole Stát/Země/Provincie během registrace',
         'group_search_results_by_product'                  => 'Skupinové hledání - výsledky produktů',
         'group_search_results_by_product_comment'          => 'Produkt zobrazit ve výsledcích hledání pouze jednou, nezobrazovat všechny varianty',
+        'shipping_selection_before_payment' => 'Select shipping method BEFORE payment during checkout',
+        'shipping_selection_before_payment_comment' => 'By default, during checkout, the user is first asked to select a payment method before selecting a shipping method; use this option to reverse this logic',
         'admin_email'                => 'Email správce',
         'admin_email_comment'        => 'Zprávy pro správce budou zasílány na tuto adresu',
         'base'                       => 'Základní nastavení',

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -163,6 +163,8 @@
         'use_state_comment' => 'Kunden müssen bei der Registrierung ein Kanton/Bundesstaat auswählen',
         'group_search_results_by_product' => 'Suchresultate nach Produkt gruppieren',
         'group_search_results_by_product_comment' => 'Zeige in den Suchresultaten nur das Hauptprodukt an, nicht alle passenden Varianten',
+        'shipping_selection_before_payment' => 'Select shipping method BEFORE payment during checkout',
+        'shipping_selection_before_payment_comment' => 'By default, during checkout, the user is first asked to select a payment method before selecting a shipping method; use this option to reverse this logic',
         'admin_email' => 'E-Mail des Admins',
         'admin_email_comment' => 'Benachrichtigungen werden an diese E-Mail versendet',
         'base' => 'Allgemein',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -164,6 +164,8 @@ return [
         'use_state_comment' => 'Customers have to select a State/County/Province during signup',
         'group_search_results_by_product' => 'Group search results by product',
         'group_search_results_by_product_comment' => 'Include a Product only once in the search results, don\'t display all matching Variants',
+        'shipping_selection_before_payment' => 'Select shipping method BEFORE payment during checkout',
+        'shipping_selection_before_payment_comment' => 'By default, during checkout, the user is first asked to select a payment method before selecting a shipping method; use this option to reverse this logic',
         'admin_email' => 'Admin email',
         'admin_email_comment' => 'Admin notifications will be sent to this addres',
         'base' => 'Base settings',

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -163,6 +163,8 @@
         'use_state_comment' => 'Los clientes deben seleccionar un Estado/País/Provincia durante el registro',
         'group_search_results_by_product' => 'Agrupar resultados por producto',
         'group_search_results_by_product_comment' => 'Mostrar un Producto sólo una vez en resultados de búsqueda, no incluir las Variantes',
+        'shipping_selection_before_payment' => 'Select shipping method BEFORE payment during checkout',
+        'shipping_selection_before_payment_comment' => 'By default, during checkout, the user is first asked to select a payment method before selecting a shipping method; use this option to reverse this logic',
         'admin_email' => 'Email del administrador',
         'admin_email_comment' => 'Las notificaciones de administración serán enviadas a esta dirección',
         'base' => 'Ajustes de Base',

--- a/lang/fa/lang.php
+++ b/lang/fa/lang.php
@@ -161,6 +161,8 @@
         'use_state_comment'          => 'مشتریان مجبور به انتخاب استان/ایالت در هنگام ثبت نام باشند',
         'group_search_results_by_product'                  => ' گروه بندی نتیجه جستجو براساس محصول ',
         'group_search_results_by_product_comment'          => 'فقط یک بار در نتایج جستجو یک محصول را نمایش دهد ، تمام متغیرهای مطابق با آنها نمایش داده نشود',
+        'shipping_selection_before_payment' => 'Select shipping method BEFORE payment during checkout',
+        'shipping_selection_before_payment_comment' => 'By default, during checkout, the user is first asked to select a payment method before selecting a shipping method; use this option to reverse this logic',
         'admin_email'                => 'ایمیل مدیریت',
         'admin_email_comment'        => 'اعلان های مدیریت به این آدرس ایمیل ارسال می شوند',
         'base'                       => 'تنظمیات پایه',

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -163,6 +163,8 @@
         'use_state_comment' => 'Les clients doivent sélectionner un État/Province/Région lors de l\'inscription',
         'group_search_results_by_product' => 'Regrouper les résultats de la recherche par produit',
         'group_search_results_by_product_comment' => 'Inclure un produit une seule fois dans les résultats de recherche, ne pas afficher toutes les variantes correspondantes',
+        'shipping_selection_before_payment' => 'Select shipping method BEFORE payment during checkout',
+        'shipping_selection_before_payment_comment' => 'By default, during checkout, the user is first asked to select a payment method before selecting a shipping method; use this option to reverse this logic',
         'admin_email' => 'Email de l\'administrateur',
         'admin_email_comment' => 'Les notifications de l\'administrateur seront envoyées à cette adresse',
         'base' => 'Paramètres de base',

--- a/models/settings/fields_general.yaml
+++ b/models/settings/fields_general.yaml
@@ -96,3 +96,10 @@ fields:
         type: switch
         default: 0
         comment: offline.mall::lang.general_settings.group_search_results_by_product_comment
+
+    shipping_selection_before_payment:
+        label: offline.mall::lang.general_settings.shipping_selection_before_payment
+        span: left
+        type: switch
+        default: 0
+        comment: offline.mall::lang.general_settings.shipping_selection_before_payment_comment


### PR DESCRIPTION
Attempt to resolve [Checkout : Shipping before payment #303](https://github.com/OFFLINE-GmbH/oc-mall-plugin/issues/303)

Note that I've just started working with this (awesome!) plugin, so this PR should really be reviewed & tested. I added a new option to the plugin backend "General" config page, under "Customization", called "Select shipping method BEFORE payment during checkout". It's a toggle that's off by default (original behavior). Toggle it on to switch the order of the Shipping & Payment screens so that shipping comes before payment. 

Specifically, the following changes in behavior where made (when the option is toggled on):

1. During checkout, if no step is provided then the default step becomes "shipping" instead of payment
1. The redirect methods are updated in the PaymentMethodSelector as well as the ShippingMethodSelector components, so that the "next step" after shipping is the payment page, and the "next step" after payment is the confirmation page.
1. A new variable $shippingSelectionBeforePayment is added to the Checkout, PaymentMethodSelector, and ShippingMethodSelector  components; this helps with adjusting the theme to reverse the order of the buttons or anything else that is needed to properly handle this change in checkout behavior.

I'm using the "[ketikidis emarket](https://octobercms.com/theme/ketikidis-emarket)" theme for this plugin, so I did not make the necessary changes in the default theme for this plugin to support this new functionality. Perhaps someone else can?