### PR TITLE
Fix money rounding

### DIFF
--- a/classes/utils/DefaultMoney.php
+++ b/classes/utils/DefaultMoney.php
@@ -17,7 +17,7 @@ class DefaultMoney implements Money
         $this->twig = App::make('mall.twig.environment');
     }
 
-    public function format(?int $value, $product = null, ?Currency $currency = null): string
+    public function format(?float $value, $product = null, ?Currency $currency = null): string
     {
         $currency = $currency ?? Currency::activeCurrency();
 

--- a/classes/utils/Money.php
+++ b/classes/utils/Money.php
@@ -6,7 +6,7 @@ use OFFLINE\Mall\Models\Currency;
 
 interface Money
 {
-    public function format(?int $value, $product = null, ?Currency $currency = null): string;
+    public function format(?float $value, $product = null, ?Currency $currency = null): string;
 
     public function round($value, $decimals = 2): float;
 }


### PR DESCRIPTION
Currently the `|money` twig filter can be one number off on the last decimal when it's used on a total from the `TotalsCalculator`. This pull request fixes that. This occurs when one of the calculated totals has more decimals than the used currency and needs rounding.

How to reproduce the problem:
- Use a currency with 2 decimals
- Put a product with a price of 243.40 and 6% tax in the `TotalsCalculator`
- Output the `TotalsCalculator`'s `productPreTaxes()`, `productTaxes()`, `productPostTaxes()` via the `|money` twig filter
- The sum of `productPreTaxes()` and `productTaxes()` will be 0.01 off from `productPostTaxes()`