### PR TITLE
Small fix for variants in the resolveItem() method

### DIFF
--- a/models/Variant.php
+++ b/models/Variant.php
@@ -378,7 +378,7 @@ class Variant extends Model
             ->map(function (self $variant) use ($cmsPage, $page, $url) {
                 $pageUrl = $cmsPage->url($page, [
                     'slug'    => $variant->product->slug,
-                    'variant' => $variant->variantId,
+                    'variant' => $variant->variantHashId,
                 ]);
 
                 return [


### PR DESCRIPTION
This fixes a small issue where the product variant id is an int instead of the hashed id, for example in generated sitemaps.