### PR TITLE
Add paymentMethodSelector to quickcheckout cancelled state

### DIFF
--- a/components/QuickCheckout.php
+++ b/components/QuickCheckout.php
@@ -173,6 +173,8 @@ class QuickCheckout extends MallComponent
             $this->addComponent(AddressSelector::class, 'shippingAddressSelector', ['type' => 'shipping', 'redirect' => 'quickCheckout']);
         } elseif ($this->step === 'payment') {
             $this->addComponent(PaymentMethodSelector::class, 'paymentMethodSelector', []);
+        } elseif ($this->step === 'cancelled') {
+            $this->addComponent(PaymentMethodSelector::class, 'paymentMethodSelector', []);
         }
         $this->setData();
     }

--- a/components/quickcheckout/steps/cancelled.htm
+++ b/components/quickcheckout/steps/cancelled.htm
@@ -3,3 +3,5 @@
     <p>{{ 'offline.mall::frontend.checkout.payment.cancelled.line_1' | trans }}</p>
     {% partial __SELF__ ~ '::resultactions' %}
 </div>
+
+{% component 'paymentMethodSelector' %}


### PR DESCRIPTION
When the payment is cancelled by the user, give him the ability to pay again.

![image](https://user-images.githubusercontent.com/7849550/100553242-19d37c80-328d-11eb-8049-5e6f85ffe2d3.png)


