### PR TITLE
fix a bug, when user is logged in, but is not a customer

### DIFF
--- a/components/ProductReviews.php
+++ b/components/ProductReviews.php
@@ -113,7 +113,7 @@ class ProductReviews extends ComponentBase
             ->when($this->property('variant'), function ($q) {
                 $q->where('variant_id', $this->property('variant'));
             })
-            ->when(Auth::getUser(), function ($q) {
+            ->when(Auth::getUser() && Auth::getUser()->customer, function ($q) {
                 $q->where('customer_id', Auth::getUser()->customer->id);
             }, function ($q) {
                 $q->where('user_hash', Review::getUserHash());

--- a/components/ProductReviews.php
+++ b/components/ProductReviews.php
@@ -113,7 +113,7 @@ class ProductReviews extends ComponentBase
             ->when($this->property('variant'), function ($q) {
                 $q->where('variant_id', $this->property('variant'));
             })
-            ->when(Auth::getUser() && Auth::getUser()->customer, function ($q) {
+            ->when(optional(Auth::getUser())->customer, function ($q) {
                 $q->where('customer_id', Auth::getUser()->customer->id);
             }, function ($q) {
                 $q->where('user_hash', Review::getUserHash());


### PR DESCRIPTION
Otherwise `$q->where('customer_id', Auth::getUser()->customer->id);` would led to a null exception.