### PR TITLE
Changing default price when creating a new product.

### DIFF
--- a/formwidgets/Price.php
+++ b/formwidgets/Price.php
@@ -13,6 +13,8 @@ class Price extends FormWidgetBase
 
     protected $defaultAlias = 'price';
 
+    public $value = null;
+
     public function init()
     {
         $this->defaultCurrency = Currency::orderBy('is_default', 'DESC')->first();
@@ -83,7 +85,11 @@ class Price extends FormWidgetBase
     public function prepareVars()
     {
         $this->vars['defaultCurrency'] = $this->defaultCurrency;
-        $this->vars['defaultValue']    = $this->getPriceValue($this->defaultCurrency->id);
+        if ($this->value) {
+            $this->vars['defaultValue'] = $this->value;
+        } else {
+            $this->vars['defaultValue'] = $this->getPriceValue($this->defaultCurrency->id);
+        }
         $this->vars['currencies']      = Currency::orderBy('sort_order', 'ASC')->get();
         $this->vars['field']           = $this->formField;
     }

--- a/formwidgets/Price.php
+++ b/formwidgets/Price.php
@@ -85,11 +85,7 @@ class Price extends FormWidgetBase
     public function prepareVars()
     {
         $this->vars['defaultCurrency'] = $this->defaultCurrency;
-        if ($this->value) {
-            $this->vars['defaultValue'] = $this->value;
-        } else {
-            $this->vars['defaultValue'] = $this->getPriceValue($this->defaultCurrency->id);
-        }
+        $this->vars['defaultValue']    = $this->getPriceValue($this->defaultCurrency->id);
         $this->vars['currencies']      = Currency::orderBy('sort_order', 'ASC')->get();
         $this->vars['field']           = $this->formField;
     }
@@ -105,7 +101,7 @@ class Price extends FormWidgetBase
     {
         $value = $this->getLoadValue();
         if ( ! $value) {
-            return null;
+            return $this->value;
         }
 
         return $value->where('currency_id', $currency)->first()->decimal ?? false;


### PR DESCRIPTION
adding `$value` to Price widget.

With that, developers can set a default price for a new product.

```php
class Plugin {
    public function boot() {
        Product::extend(function (Product $model) {
            $model->bindEvent('model.form.filterFields', function (\Backend\Widgets\Form $formWidget, $fields, $context) use ($model) {

                if ($context !== 'create') {
                    return;
                }

                $formWidget->getFormWidget('_initial_price')->value = "5";
            })
   [..]
}

```