### PR TITLE
Add search and record limitation to properties

### DIFF
--- a/controllers/propertygroups/config_relation.yaml
+++ b/controllers/propertygroups/config_relation.yaml
@@ -15,5 +15,7 @@ properties:
     manage:
         form: $/offline/mall/models/property/fields_pivot.yaml
         list: $/offline/mall/models/property/columns.yaml
+        showSearch: true
+        recordsPerPage: 50
     pivot:
         form: $/offline/mall/models/property/fields_pivot.yaml


### PR DESCRIPTION
If you have a lot of properties (1000+), this interface becomes unusable otherwise.
Like this, it is nicely searchable and paginated.