### PR TITLE
Payment step: Redirect to login

### DIFF
--- a/components/QuickCheckout.php
+++ b/components/QuickCheckout.php
@@ -18,6 +18,7 @@ use OFFLINE\Mall\Models\ShippingMethod;
 use OFFLINE\Mall\Models\User;
 use RainLab\Location\Models\Country;
 use Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
 
 /**
  * The QuickCheckout component provides a checkout process on a single page.
@@ -174,6 +175,13 @@ class QuickCheckout extends MallComponent
             $this->addComponent(AddressSelector::class, 'shippingAddressSelector', ['type' => 'shipping', 'redirect' => 'quickCheckout']);
         } elseif ($this->step === 'payment' || $this->step === 'cancelled') {
             $this->addComponent(PaymentMethodSelector::class, 'paymentMethodSelector', []);
+            
+            // Payment step guard
+            // Redirect user to the login page when they request order details while not logged in
+            $orderId = request()->get('order');
+            if ($orderId && $currentUser === null) {
+                throw new HttpResponseException(redirect($this->property('loginPage')));
+            }
         }
         $this->setData();
     }

--- a/components/QuickCheckout.php
+++ b/components/QuickCheckout.php
@@ -19,6 +19,7 @@ use OFFLINE\Mall\Models\User;
 use RainLab\Location\Models\Country;
 use Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use RainLab\User\Facades\Auth as FrontendAuth;
 
 /**
  * The QuickCheckout component provides a checkout process on a single page.
@@ -179,7 +180,7 @@ class QuickCheckout extends MallComponent
             // Payment step guard
             // Redirect user to the login page when they request order details while not logged in
             $orderId = request()->get('order');
-            if ($orderId && $currentUser === null) {
+            if ($orderId && !FrontendAuth::check()) {
                 throw new HttpResponseException(redirect($this->property('loginPage')));
             }
         }


### PR DESCRIPTION
Currently, it throws this error (from the demo site):

`Type error: Argument 1 passed to OFFLINE\Mall\Models\Order::byCustomer() must be an instance of OFFLINE\Mall\Models\Customer, null given, called in /home/offlineg/public_html/_domains/mall.offline.swiss/plugins/offline/mall/components/QuickCheckout.php on line 413`

When the user is requesting the payment step with the order parameter and they are not logged in, redirect the user to the login page. Bypassing the byCustomer() completely.