### PR TITLE
Use QueryString "category_id" filter when present instead of category calculated based on component properties

### DIFF
--- a/components/Products.php
+++ b/components/Products.php
@@ -468,7 +468,7 @@ class Products extends MallComponent
         $filter = array_wrap($filter);
 
         $filters = (new QueryString())->deserialize($filter, $this->category);
-        if ($this->categories) {
+        if ($this->categories && !isset($filters['category_id'])) {
             $filters->put('category_id', new SetFilter('category_id', $this->categories->pluck('id')->toArray()));
         }
 


### PR DESCRIPTION
This PR add a small condition to getFilters method of product component.

If category_id key is detected on the QueryString, we don't override it by defining categories using component properties. It allow to use filter system with categories.