### PR TITLE
Add support for winterCMS

### DIFF
--- a/controllers/Products.php
+++ b/controllers/Products.php
@@ -54,7 +54,10 @@ class Products extends Controller
             // existence and doesn't inherit the parent product's data if it exists.
             session()->flash('mall.variants.disable-inheritance');
 
-            if (str_contains(\Request::header('X-OCTOBER-REQUEST-HANDLER',''), 'PriceTable')) {
+            $requestFromOctoberCMS = str_contains(\Request::header('X-OCTOBER-REQUEST-HANDLER',''), 'PriceTable');
+            $requestFromWinterCMS  = str_contains(\Request::header('X-WINTER-REQUEST-HANDLER',''), 'PriceTable');
+            
+            if ($requestFromOctoberCMS || $requestFromWinterCMS) {
                 $this->preparePriceTable();
             }
         }

--- a/models/Variant.php
+++ b/models/Variant.php
@@ -399,10 +399,13 @@ class Variant extends Model
 
     protected function isBackendRelationUpdate(): bool
     {
+        $backendReqByOctoberCMS = starts_with(request()->header('X-OCTOBER-REQUEST-HANDLER'), 'onRelationManage');
+        $backendReqByWinterCMS = starts_with(request()->header('X-WINTER-REQUEST-HANDLER'), 'onRelationManage');
+        
         return app()->runningInBackend()
             && request('Variant')
             && request('MallPrice')
             && request('_relation_field') === 'variants'
-            && starts_with(request()->header('X-OCTOBER-REQUEST-HANDLER'), 'onRelationManage');
+            && ($backendReqByOctoberCMS || $backendReqByWinterCMS);
     }
 }

--- a/models/Variant.php
+++ b/models/Variant.php
@@ -1,5 +1,6 @@
 <?php namespace OFFLINE\Mall\Models;
 
+use App;
 use Cms\Classes\Page;
 use DB;
 use Html;
@@ -399,13 +400,10 @@ class Variant extends Model
 
     protected function isBackendRelationUpdate(): bool
     {
-        $backendReqByOctoberCMS = starts_with(request()->header('X-OCTOBER-REQUEST-HANDLER'), 'onRelationManage');
-        $backendReqByWinterCMS = starts_with(request()->header('X-WINTER-REQUEST-HANDLER'), 'onRelationManage');
-        
         return app()->runningInBackend()
             && request('Variant')
             && request('MallPrice')
             && request('_relation_field') === 'variants'
-            && ($backendReqByOctoberCMS || $backendReqByWinterCMS);
+            && App::runningInBackend();
     }
 }


### PR DESCRIPTION
Quick and easy fix. This solution isn't DRY enough

Since OctoberCMS changes their licences, some of the original Devs forked octoberCMS version 472 and called it winterCMS. The `X-WINTER-REQUEST-HANDLER` is the header type used by winterCMS when creating XHR request (I assume all. But I've only found this when making a backend XHR request) as opposed to `X-OCTOBER-REQUEST-HANDLER`.

When we use this plugin with winterCMS, even though as of now there's no apparent difference between the two (in terms of how plugins are handled) there should be no reason why this plugin shouldn't work with winterCMS.

This plugin checks if it's running from the backend by checking the `X-OCTOBER-REQUEST-HANDLER`, something that winterCMS didn't send.

What my fix does is add the check to `X-WINTER-REQUEST-HANDLER` so that the plugin can properly initialise itself when called from the backend.

Edit: original description is unclear.