### PR TITLE
Show message when shipping method is not selected

### DIFF
--- a/components/cart/table/shipping.htm
+++ b/components/cart/table/shipping.htm
@@ -1,13 +1,23 @@
 {% if __SELF__.showShipping %}
-    <tr class="mall-cart__shipping">
-        <td></td>
-        <td colspan="3">
-            {{ shipping.method.name }}
-        </td>
-        <td class="text-right">
-            {{ shipping.totalPostTaxes | money }}
-        </td>
-    </tr>
+    {% if shipping.method is not null %}
+        <tr class="mall-cart__shipping">
+            <td></td>
+            <td colspan="3">
+                {{ shipping.method.name }}
+            </td>
+            <td class="text-right">
+                {{ shipping.totalPostTaxes | money }}
+            </td>
+        </tr>
+    {% else %}
+        <tr class="mall-cart__shipping mall-cart__noShippingMethod">
+            <td></td>
+            <td colspan="3">
+                {{ 'offline.mall::frontend.no_shipping_method' | trans }}
+            </td>
+            <td></td>
+        </tr>
+    {% endif %}
 {% else %}
     {% partial __SELF__ ~ '::shippingexcluded' %}
 {% endif %}

--- a/components/quickcheckout/carttable/shipping.htm
+++ b/components/quickcheckout/carttable/shipping.htm
@@ -1,8 +1,17 @@
-<tr class="mall-cart__shipping">
-    <td>
-        {{ shipping.method.name }}
-    </td>
-    <td class="text-right">
-        {{ shipping.totalPostTaxes | money }}
-    </td>
-</tr>
+{% if shipping.method is not null %}
+    <tr class="mall-cart__shipping">
+        <td>
+            {{ shipping.method.name }}
+        </td>
+        <td class="text-right">
+            {{ shipping.totalPostTaxes | money }}
+        </td>
+    </tr>
+{% else %}
+    <tr class="mall-cart__shipping mall-cart__noShippingMethod">
+        <td>
+            {{ 'offline.mall::frontend.no_shipping_method' | trans }}
+        </td>
+        <td></td>
+    </tr>
+{% endif %}

--- a/lang/en/frontend.php
+++ b/lang/en/frontend.php
@@ -164,4 +164,5 @@ return [
     'reviews.ratings' => 'rating|ratings',
     'reviews.optional' => 'Optional, but helps to understand your rating better',
     'reviews.one_per_line' => 'Optional, put every entry on its own line',
+    'no_shipping_method' => 'No shipping selected',
 ];


### PR DESCRIPTION
In the cart view, when no shipping method is selected, show a message instead of empty name and zero price.