### PR TITLE
Catch ModelNotFoundException

### DIFF
--- a/components/Cart.php
+++ b/components/Cart.php
@@ -216,7 +216,7 @@ class Cart extends MallComponent
         }
 
         return [
-            'item'     => null,
+            'item'     => (new CartProduct)->toArray(),
             'quantity' => 0,
             'new_items_count' => optional($cart->products)->count() ?? 0,
             'new_items_quantity' => optional($cart->products)->sum('quantity') ?? 0,

--- a/components/Cart.php
+++ b/components/Cart.php
@@ -204,20 +204,13 @@ class Cart extends MallComponent
         
         if ($product != null) {
             $cart->removeProduct($product);
-
-            $this->setData();
-
-            return [
-                'item'     => $this->dataLayerArray($product->product, $product->variant),
-                'quantity' => $product->quantity,
-                'new_items_count' => optional($cart->products)->count() ?? 0,
-                'new_items_quantity' => optional($cart->products)->sum('quantity') ?? 0,
-            ];
         }
+        
+        $this->setData();
 
         return [
-            'item'     => (new CartProduct)->toArray(),
-            'quantity' => 0,
+            'item'     => $product ? $this->dataLayerArray($product->product, $product->variant) : (new CartProduct)->toArray(),
+            'quantity' => optional($product)->quantity ?? 0,
             'new_items_count' => optional($cart->products)->count() ?? 0,
             'new_items_quantity' => optional($cart->products)->sum('quantity') ?? 0,
         ];

--- a/components/Cart.php
+++ b/components/Cart.php
@@ -201,14 +201,23 @@ class Cart extends MallComponent
         $cart = CartModel::byUser(Auth::getUser());
 
         $product = $this->getProductFromCart($cart, $id);
+        
+        if ($product != null) {
+            $cart->removeProduct($product);
 
-        $cart->removeProduct($product);
+            $this->setData();
 
-        $this->setData();
+            return [
+                'item'     => $this->dataLayerArray($product->product, $product->variant),
+                'quantity' => $product->quantity,
+                'new_items_count' => optional($cart->products)->count() ?? 0,
+                'new_items_quantity' => optional($cart->products)->sum('quantity') ?? 0,
+            ];
+        }
 
         return [
-            'item'     => $this->dataLayerArray($product->product, $product->variant),
-            'quantity' => $product->quantity,
+            'item'     => null,
+            'quantity' => 0,
             'new_items_count' => optional($cart->products)->count() ?? 0,
             'new_items_quantity' => optional($cart->products)->sum('quantity') ?? 0,
         ];
@@ -251,12 +260,16 @@ class Cart extends MallComponent
      */
     protected function getProductFromCart(CartModel $cart, $id)
     {
-        return CartProduct
-            ::whereHas('cart', function ($query) use ($cart) {
-                $query->where('id', $cart->id);
-            })
-            ->where('id', $id)
-            ->firstOrFail();
+        try {
+            return CartProduct
+                ::whereHas('cart', function ($query) use ($cart) {
+                    $query->where('id', $cart->id);
+                })
+                ->where('id', $id)
+                ->firstOrFail();
+        } catch (ModelNotFoundException $e) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
When removing an item from the cart that has been removed (either from the quick checkout page or cart page from another tab), the firstOrFail will throw a ModelNotFoundException. The proposed change will catch the ModelNotFoundException and return null instead. The onRemoveProduct function can then null-check the $product before removing the product.