### PR TITLE
Attribute {{ items }} variable to page scope

### DIFF
--- a/components/WishlistButton.php
+++ b/components/WishlistButton.php
@@ -46,7 +46,7 @@ class WishlistButton extends MallComponent
 
     public function init()
     {
-        $this->items = $this->getWishlists();
+        $this->items = $this->page['items'] = $this->getWishlists();
     }
 
     /**
@@ -94,6 +94,8 @@ class WishlistButton extends MallComponent
         ]);
 
         Flash::success(trans('offline.mall::frontend.wishlist.added'));
+        
+        $this->page['items'] = $this->getWishlists();
 
         return [
             '.mall-wishlists' => $this->renderPartial($this->alias . '::list', [
@@ -154,6 +156,7 @@ class WishlistButton extends MallComponent
      */
     protected function refreshList(): array
     {
+        $this->page['items'] = $this->getWishlists();
         return [
             '.mall-wishlists' => $this->renderPartial($this->alias . '::list', ['items' => $this->getWishlists()]),
         ];


### PR DESCRIPTION
By adding items to $this->page['items'] instead of renderPartial function, you allow theme developpers to create their own partials and set their own wrapper, which allow more possibilities in term of theming.