### PR TITLE
Add function to calculate total fee of a payment method

### DIFF
--- a/models/PaymentMethod.php
+++ b/models/PaymentMethod.php
@@ -11,6 +11,8 @@ use October\Rain\Parse\Twig;
 use OFFLINE\Mall\Classes\Payments\PaymentGateway;
 use OFFLINE\Mall\Classes\Traits\PriceAccessors;
 use System\Models\File;
+use Auth;
+use OFFLINE\Mall\Classes\Totals\PaymentTotal;
 
 class PaymentMethod extends Model
 {
@@ -130,5 +132,11 @@ class PaymentMethod extends Model
         $provider = $gateway->getProviderById($this->payment_provider);
 
         return $provider->getSettings();
+    }
+    
+    public function priceForCart()
+    {
+        $cart    = Cart::byUser(Auth::getUser());
+        return new PaymentTotal($this, $cart->totals);
     }
 }


### PR DESCRIPTION
This PR follow [this issue](https://github.com/OFFLINE-GmbH/oc-mall-plugin/issues/817)

Can be used in twig like this (example with quickCheckout component)

{% for method in quickCheckout.paymentMethods %}
    {{ method.name }} - {{ method.priceForCart().totalPostTaxes|money }}
{% endfor %}