### PR TITLE
Allow to passe country_id as post data to refresh shipping methods

### DIFF
--- a/models/ShippingMethod.php
+++ b/models/ShippingMethod.php
@@ -154,13 +154,20 @@ class ShippingMethod extends Model
         }
 
         $total = $cart->totals()->productPostTaxes();
-
+        
+        $country_id = null;
+        if(post('country_id')) {
+            $country_id = post('country_id');
+        } elseif($cart->shipping_address) {
+            $country_id = $cart->shipping_address->country_id;
+        }
+        
         return self
             ::orderBy('sort_order')
-            ->when($cart->shipping_address, function ($q) use ($cart) {
+            ->when($country_id, function ($q) use ($cart, $country_id) {
                 $q->whereDoesntHave('countries')
-                  ->orWhereHas('countries', function ($q) use ($cart) {
-                      $q->where('country_id', $cart->shipping_address->country_id);
+                  ->orWhereHas('countries', function ($q) use ($cart, $country_id) {
+                      $q->where('country_id', $country_id);
                   });
             })
             ->get()


### PR DESCRIPTION
With that modification, if you pass country_id as post data, the ShippingMethod->getAvailableByCart() function will use that ID instead of the $cart->shipping_address->country_id.

It allow to update shipping methods accordingly to the selected country when you checkout as guest

it solve [this issue](https://github.com/OFFLINE-GmbH/oc-mall-plugin/issues/658)