### PR TITLE
Added RainLab plugins in composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "league/omnipay": "^3.2",
     "omnipay/paypal": "^3.0",
     "omnipay/stripe": "^3.0",
-    "barryvdh/laravel-dompdf": "^0.9.0"
+    "barryvdh/laravel-dompdf": "^0.9.0",
+    "rainlab/user-plugin": "^1.6"
   },
   "suggest": {
     "vitalybaev/google-merchant-feed": "Required to use the Google Merchant Feed integration",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     "omnipay/paypal": "^3.0",
     "omnipay/stripe": "^3.0",
     "barryvdh/laravel-dompdf": "^0.9.0",
-    "rainlab/user-plugin": "^1.6"
+    "rainlab/user-plugin": "^1.6",
+    "rainlab/location-plugin": "^1.1.5",
+    "rainlab/translate-plugin": "^1.9.0"
   },
   "suggest": {
     "vitalybaev/google-merchant-feed": "Required to use the Google Merchant Feed integration",


### PR DESCRIPTION
The plugin is not working out of the box because they require RainLab plugins in `Plugin.php` but are not required in the `composer.json` file. This PR should fix it and add the plugins upon installation of the Mall plugin when not installed already. 