### PR TITLE
Update WishlistButton.php

### DIFF
--- a/components/WishlistButton.php
+++ b/components/WishlistButton.php
@@ -134,6 +134,8 @@ class WishlistButton extends MallComponent
         if ($v->fails()) {
             throw new ValidationException($v);
         }
+        
+        $this->decodeIds();
 
         Wishlist::findOrFail($this->decode(post('wishlist_id')))->delete();
 


### PR DESCRIPTION
This PR fix a problem when you delete a wishlist using the wishlistButton component because the onDelete() method don't call $this->decodeIds().

So, when you delete a wishlist and refresh your partial to update the list, you can't add a product to the wishlist because that 2 parameters are empty.

To make it works, you have to add some data when you call the onDelete() method, here is an example :

data-request-data="'name':'{{ wishlist.name }}', wishlist_id: '{{ wishlist.hash_id }}', product_id: '{{ wishlistButton.encode(wishlistButton.property('product')) }}', variant_id: '{{ wishlistButton.encode(wishlistButton.property('variant')) }}'"

Best regards,