### PR TITLE
Hide unpublished product's variants

### DIFF
--- a/components/Product.php
+++ b/components/Product.php
@@ -513,7 +513,7 @@ class Product extends MallComponent
             return collect();
         }
 
-        $variants = $this->product->variants->reject(
+        $variants = $this->product->variants->where('published')->reject(
             function (Variant $variant) {
                 // Only display "other" Variants, so remove the currently displayed.
                 return $variant->id === $this->variantId;


### PR DESCRIPTION
This change is intended to hide variants that are not published.
Showing unpublished variants results in so many 404 errors on the site.