### PR TITLE
Add event hook to product's toolbar

### DIFF
--- a/controllers/products/_list_toolbar.htm
+++ b/controllers/products/_list_toolbar.htm
@@ -14,5 +14,7 @@
         data-request-success="$(this).prop('disabled', true)"
         data-stripe-load-indicator>
         <?= e(trans('backend::lang.list.delete_selected')) ?>
+
+        <?= $this->fireViewEvent('offline.mall.extendProductsToolbar') ?>
     </button>
 </div>


### PR DESCRIPTION
This proposal adds an event hook to the products controller's toolbar so that it can be easily heard from a third party plugin.

Example of use of the feature
```php
/**
* Extend products view toolbar
*/
Event::listen('offline.mall.extendProductsToolbar', function ($controller) {
        // return html button code
});
```