### PR TITLE
Pass order Id in resultaction button

### DIFF
--- a/components/checkout/resultactions.htm
+++ b/components/checkout/resultactions.htm
@@ -1,6 +1,6 @@
 
 <div class="mall-checkout-result__actions">
-    <a href="{{ __SELF__.accountPage | page({page: 'orders'}) }}" class="mall-btn mall-btn--primary">
+    <a href="{{ __SELF__.accountPage | page({page: 'orders', order:  __SELF__.order.id}) }}" class="mall-btn mall-btn--primary">
         {{ 'offline.mall::frontend.order_overview.visit' | trans }}
     </a>
 </div>

--- a/components/orderslist/details.htm
+++ b/components/orderslist/details.htm
@@ -1,4 +1,4 @@
-<tr style="display: none" class="mall-orders-list__details">
+<tr style="{{ this.param.order == order.order_number ? '': 'display: none' }}" class="mall-orders-list__details">
     <td colspan="5">
         <div class="mall-order-details">
             <div class="mall-order-details__row">

--- a/components/orderslist/orderlist.htm
+++ b/components/orderslist/orderlist.htm
@@ -8,7 +8,7 @@
             <th class="text-right">{{ 'offline.mall::frontend.total' | trans }}</th>
         </tr>
         {% for order in orders %}
-            <tr class="mall-orders-list__order {{ order.isPaid ? '' : 'mall-orders-list__order--unpaid' }}">
+            <tr class="mall-orders-list__order {{ order.isPaid ? '' : 'mall-orders-list__order--unpaid' }} {{ this.param.order == order.order_number ? 'is-open' : '' }}">
                 <td>{{ order.order_number }}</td>
                 <td>{% partial __SELF__ ~ '::created_at' order=order %}</td>
                 <td>{{ order.order_state_label }}</td>


### PR DESCRIPTION
Add order ID to checkout result button href.  
It is then possible to define the url of the page containing the `myAccount` component as follows: `url = "/account/:page?/:order?` to instantly expand the correct order in the list.

Example for [myaccount](https://offline-gmbh.github.io/oc-mall-plugin/getting-started/theme-setup.html#myaccount-htm) page : 
````twig
title = "Account"
url = "/account/:page?/:order?"
layout = "default"
is_hidden = 0

[session]
security = "user"
redirect = "login"

[myAccount]
page = "{{ :page }}"
==
{% component 'myAccount' %}
```` 