### PR TITLE
Bugfix defining starting order number

### DIFF
--- a/models/Order.php
+++ b/models/Order.php
@@ -269,7 +269,7 @@ class Order extends Model
 
         $start = $numbers->max;
 
-        if ($start === 0) {
+        if (is_null($start) || $start === 0) {
             $start = (int)GeneralSettings::get('order_start');
         }
 


### PR DESCRIPTION
Modify `Models\Order::setOrderNumber()` method to test for `null`value return by DB query in no orders are available.
Fix #716