### PR TITLE
Bug in the Cart Component with removing product: new_items_count counts removed product

### DIFF
--- a/components/Cart.php
+++ b/components/Cart.php
@@ -217,8 +217,8 @@ class Cart extends MallComponent
         return [
             'item' => $this->dataLayerArray($product->product, $product->variant),
             'quantity' => optional($product)->quantity ?? 0,
-            'new_items_count' => optional($cart->products)->count() ?? 0,
-            'new_items_quantity' => optional($cart->products)->sum('quantity') ?? 0,
+            'new_items_count' => optional($this->cart->products)->count() ?? 0,
+            'new_items_quantity' => optional($this->cart->products)->sum('quantity') ?? 0,
         ];
     }
 


### PR DESCRIPTION

After product removing cart model’s object has postponed relations (removed product observed within)
So new_items_count counts removed product
In the setData method there is updated CartModel selecting, which has stable relations, so using $this->cart helps to count new cart’s products count
Tested in the October 1.1