### PR TITLE
Bugfix mail's link on order state change

### DIFF
--- a/classes/events/MailingEventHandler.php
+++ b/classes/events/MailingEventHandler.php
@@ -179,6 +179,7 @@ class MailingEventHandler
 
         $data = [
             'order' => $order->load(['order_state']),
+            'account_url' => $this->getAccountUrl(),
         ];
 
         Mail::queue($this->template('offline.mall::order.state.changed'), $data, function ($message) use ($order) {


### PR DESCRIPTION
Add link to user account page in mail sent when order state change.
Fix #880