### PR TITLE
October v3 / Laravel 9 package support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "league/omnipay": "^3.2",
     "omnipay/paypal": "^3.0",
     "omnipay/stripe": "^3.0",
-    "barryvdh/laravel-dompdf": "^0.9.0",
+    "barryvdh/laravel-dompdf": "^0.9|^1.0",
     "rainlab/user-plugin": "^1.6",
     "rainlab/location-plugin": "^1.1.5",
     "rainlab/translate-plugin": "^1.9.0"


### PR DESCRIPTION
### Fix

This fixes the dependency only, haven't been able to test the barryvdh/laravel-dompdf:1.0 package without it. Potential fix for:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - illuminate/support[v5.6.0, ..., 5.8.x-dev] require php ^7.1.3 -> your php version (8.0.3) does not satisfy that requirement.
    - illuminate/support[v6.0.0, ..., v6.19.1] require php ^7.2 -> your php version (8.0.3) does not satisfy that requirement.
    - illuminate/support[v7.0.0, ..., v7.28.4] require php ^7.2.5 -> your php version (8.0.3) does not satisfy that requirement.
    - illuminate/support[v8.0.0, ..., v8.11.2] require php ^7.3 -> your php version (8.0.3) does not satisfy that requirement.
    - Root composer.json requires offline/oc-mall-plugin ^1.16 -> satisfiable by offline/oc-mall-plugin[v1.16.0].
    - Conclusion: don't install laravel/framework v9.0.0-beta.2 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.0.0-beta.3 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.0.0-beta.4 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.0.0-beta.5 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.0.0 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.0.1 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.0.2 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.1.0 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.2.0 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.3.0 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.3.1 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.4.0 (conflict analysis result)
    - Conclusion: don't install laravel/framework v9.4.1 (conflict analysis result)
    - offline/oc-mall-plugin v1.16.0 requires barryvdh/laravel-dompdf ^0.9.0 -> satisfiable by barryvdh/laravel-dompdf[v0.9.0].
    - Conclusion: don't install laravel/framework v9.0.0-beta.1 (conflict analysis result)
    - barryvdh/laravel-dompdf v0.9.0 requires illuminate/support ^5.5|^6|^7|^8 -> satisfiable by illuminate/support[v5.5.0, ..., 5.8.x-dev, v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev].
    - Only one of these can be installed: illuminate/support[v5.5.0, ..., 5.8.x-dev, v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev, v9.0.0-beta.1, ..., 9.x-dev], laravel/framework[v9.0.0-beta.1, ..., 9.x-dev]. laravel/framework replaces illuminate/support and thus cannot coexist with it.
    - Root composer.json requires laravel/framework ^9.0 -> satisfiable by laravel/framework[v9.0.0-beta.1, ..., 9.x-dev].
```

### Notices

From `barryvdh/laravel-dompdf`
> Breaking change/fix: setEncryption now works as expected.

Related: https://github.com/barryvdh/laravel-dompdf/releases/tag/v1.0.0