### PR TITLE
Add event to shipping methods availability

### DIFF
--- a/docs/development/events.md
+++ b/docs/development/events.md
@@ -91,6 +91,16 @@ argument.
 This event is emitted when there was a problem during the checkout process. It receives a `PaymentResult` as a single 
 argument.
 
+## Shipping
+
+### `mall.shipping.methods.availability`
+
+This event is emitted immediately after the shipping methods have been filtered according to their availability by country and the total amount of the cart. It receives the following arguments:
+
+* `ShippingMethod` collection of all available shipping methods
+* `Cart` the current cart 
+* `Whishlist` the current whishlist
+
 ## Review
 
 ### `mall.review.created`


### PR DESCRIPTION
This event extend the shipping methods filtering process to allow third-party plugins to filter themselves the available shipping methods.

The above example show how to reject a shipping method by his ID if the cart contains a product in a specific category.
````php
Event::listen('mall.shipping.methods.availability', function (&$availableShippingMethods, $cart, $whishlist) {
    // Check if cart contains products in a specific category
    $inCategory = $cart->products->contains(function ($product) {
        return $product->product->categories->where('code', 'my-category-code')->count() > 0;
    });

    // Reject some shipping methods
    $availableShippingMethods = $availableShippingMethods->reject(function ($item) use ($inCategory) {
        return ($item->id == 2 && $inCategory);
    });
});
````