### PR TITLE
Fixed bug -- Declaration of OFFLINE\Mall\Models\ShippingMethod::jsonSerialize() must be compatible ...

### DIFF
--- a/models/ShippingMethod.php
+++ b/models/ShippingMethod.php
@@ -234,7 +234,7 @@ class ShippingMethod extends Model
         return $this->priceAccessorPriceRelation($currency, $relation, $filter);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $base = parent::jsonSerialize();
         $this->prices->load('currency');


### PR DESCRIPTION
```
In ShippingMethod.php line 237:
                                                                                                                                                         
  Declaration of OFFLINE\Mall\Models\ShippingMethod::jsonSerialize() must be compatible with Illuminate\Database\Eloquent\Model::jsonSerialize(): mixed 
```