### PR TITLE
Fix issues with newer Laravel versions.

### DIFF
--- a/models/PropertyGroup.php
+++ b/models/PropertyGroup.php
@@ -96,7 +96,9 @@ class PropertyGroup extends Model
 
     public function getDisplayNameAttribute()
     {
-        if ($this->getOriginal('display_name')) {
+        $method = method_exists($this, 'getRawOriginal') ? 'getRawOriginal' : 'getOriginal';
+
+        if ($this->{$method}('display_name')) {
             return $this->getAttributeTranslated('display_name');
         }
 

--- a/models/ShippingMethod.php
+++ b/models/ShippingMethod.php
@@ -234,7 +234,7 @@ class ShippingMethod extends Model
         return $this->priceAccessorPriceRelation($currency, $relation, $filter);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $base = parent::jsonSerialize();
         $this->prices->load('currency');


### PR DESCRIPTION
Laravel 7+ introduced changes to getOriginal() which cause infinite loop when called from within an accessor.
(see https://laravel.com/docs/7.x/upgrade#factory-types)

Laravel now uses method return signatures which must be honored when overriding methods. This PR also fixes the ShippingMethod::jsonSerialize() signature.