### PR TITLE
Fix created_at format error when updating index table

### DIFF
--- a/classes/index/ProductEntry.php
+++ b/classes/index/ProductEntry.php
@@ -22,7 +22,7 @@ class ProductEntry implements Entry
         // Make sure variants inherit product data again.
         session()->forget('mall.variants.disable-inheritance');
 
-        $data                = $product->attributesToArray();
+        $data                = $product->getAttributes();
         $data['index']       = self::INDEX;
         $data['on_sale']     = $product->on_sale;
         $data['category_id'] = $product->categories->pluck('id');

--- a/models/Product.php
+++ b/models/Product.php
@@ -621,4 +621,9 @@ class Product extends Model
             'variant' => 'offline.mall::lang.variant.method.variant',
         ];
     }
+
+    public function getCreatedAtAttribute($value)
+    {
+        return new \Carbon\Carbon($value);
+    }
 }

--- a/models/Product.php
+++ b/models/Product.php
@@ -622,7 +622,7 @@ class Product extends Model
         ];
     }
 
-    public function getCreatedAtAttribute($value)
+    public function setCreatedAtAttribute($value)
     {
         return new \Carbon\Carbon($value);
     }

--- a/models/Product.php
+++ b/models/Product.php
@@ -621,9 +621,4 @@ class Product extends Model
             'variant' => 'offline.mall::lang.variant.method.variant',
         ];
     }
-
-    public function setCreatedAtAttribute($value)
-    {
-        return new \Carbon\Carbon($value);
-    }
 }


### PR DESCRIPTION
When updating a Product, I get the following error:
```
"SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '2022-06-01T03:48:31.000000Z' for column `natasha_aerocom`.`offline_mall_index`.`created_at` at row 1 (SQL: update `offline_mall_index` set `created_at` = 2022-06-01T03:48:31.000000Z where `id` = 1)" on line 742 of /var/www/vhosts/aerocom.studioazura.com/public_html/vendor/laravel/framework/src/Illuminate/Database/Connection.php
```
This PR addresses the issue.

It's also possible to convert `created_at` value in `classes/index/mysql/MySQL.php` ... not sure which one is best.