### PR TITLE
Update Address columns definition

### DIFF
--- a/models/address/columns.yaml
+++ b/models/address/columns.yaml
@@ -47,11 +47,11 @@ columns:
         searchable: true
         invisible: true
         sortable: true
-    customer_id:
+    customer_name:
         label: 'offline.mall::lang.order.customer'
         type: text
         sortable: true
-        select: name
+        select: concat(firstname, ' ', lastname)
         relation: customer
     created_at:
         label: 'offline.mall::lang.common.created_at'


### PR DESCRIPTION
I see that event in the demo site, the `customer` column when viewing addresses is always empty.  
This modification add the correct information to the column.  
The column was rename to suit October's documentation : 
> Be careful not to name relations the same as existing database columns. For example, using a name group_id could break the group relation due to a naming conflict.  

see : [Backend / Lists / Relation](https://docs.octobercms.com/2.x/backend/lists.html#relation)