### PR TITLE
Allow wishlist load by page parameter

### DIFF
--- a/components/Wishlists.php
+++ b/components/Wishlists.php
@@ -87,7 +87,11 @@ class Wishlists extends MallComponent
         /** @var Collection<Wishlist>|Wishlist[] items */
         /** @var Wishlist currentItem */
         $this->items       = $this->getWishlists();
-        $this->currentItem = $this->items->first();
+        $this->currentItem = $this->items->find($this->decode($this->param('id')));
+
+        if (! $this->currentItem) {
+            $this->currentItem = $this->items->first();
+        }
 
         $this->handleShipping();
 

--- a/components/Wishlists.php
+++ b/components/Wishlists.php
@@ -87,11 +87,7 @@ class Wishlists extends MallComponent
         /** @var Collection<Wishlist>|Wishlist[] items */
         /** @var Wishlist currentItem */
         $this->items       = $this->getWishlists();
-        $this->currentItem = $this->items->find($this->decode($this->param('id')));
-
-        if (! $this->currentItem) {
-            $this->currentItem = $this->items->first();
-        }
+        $this->currentItem = $this->items->find($this->decode($this->param('id'))) ?: $this->items->first();
 
         $this->handleShipping();
 


### PR DESCRIPTION
This PR is aimed to allow Wishlist page to load a specific wish list item by passing his hashed Id as parameter.   
**The `id` parameter must be set with an hash id** : `https://mall.offline.swiss/en/wishlists/r8dolq6Z`.
```twig
title = "Wishlists"
url = "/wishlists/:id?"
layout = "default"
is_hidden = 0

[viewBag]
localeUrl[de] = "/wunschlisten/:id?"

[wishlists]
showShipping = 1
==
{% component 'wishlists' %}
```
If no id parameter is passed, the defaut behavior is used and the first item of the list get loaded.  

This can be useful if you dynamically build a wishlist from the items in the store (example project configurator) and you want to  redirect the visitor to this newly created list.