### PR TITLE
Fixes missing method MailingEventHandler::__invoke()

### DIFF
--- a/classes/events/MailingEventHandler.php
+++ b/classes/events/MailingEventHandler.php
@@ -36,15 +36,15 @@ class MailingEventHandler
         $eventMap = [
             'offline.mall::customer.created'    => [
                 'event'   => 'mall.customer.afterSignup',
-                'handler' => 'MailingEventHandler@customerCreated',
+                'handler' => '\offline\mall\classes\events\MailingEventHandler@customerCreated',
             ],
             'offline.mall::order.state.changed' => [
                 'event'   => 'mall.order.state.changed',
-                'handler' => 'MailingEventHandler@orderStateChanged',
+                'handler' => '\offline\mall\classes\events\MailingEventHandler@orderStateChanged',
             ],
             'offline.mall::order.shipped'       => [
                 'event'   => 'mall.order.shipped',
-                'handler' => 'MailingEventHandler@orderShipped',
+                'handler' => '\offline\mall\classes\events\MailingEventHandler@orderShipped',
             ],
         ];
 


### PR DESCRIPTION
This commit fixes this issue https://github.com/OFFLINE-GmbH/oc-mall-plugin/issues/952 (Call to undefined method OFFLINE\Mall\Classes\Events\MailingEventHandler::__invoke())