### PR TITLE
Avoid Currency dates to be cast as ISO dates

### DIFF
--- a/models/Currency.php
+++ b/models/Currency.php
@@ -1,5 +1,6 @@
 <?php namespace OFFLINE\Mall\Models;
 
+use DateTimeInterface;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -42,6 +43,17 @@ class Currency extends Model
     ];
     public $table = 'offline_mall_currencies';
 
+    /**
+     * Prepare a date for array / JSON serialization.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return string
+     */
+    protected function serializeDate(DateTimeInterface $date)
+    {
+        return $date->format('Y-m-d H:i:s');
+    }
+    
     public function getRoundingOptions()
     {
         return [


### PR DESCRIPTION
Fix #954 

Cast Currency dates in `Y-m-d H:i:s` format rather than in the ISO one that is resulting in a issue when used in `rain/src/Argon/Argon.php@createFromFormatWithCurrentLocale` 
https://github.com/octobercms/library/blob/58b50c972094c95d6349c4920e0b5bf91965cc14/src/Argon/Argon.php#L44