### PR TITLE
Avoid Currency dates to be cast as ISO dates

### DIFF
--- a/models/Currency.php
+++ b/models/Currency.php
@@ -40,6 +40,10 @@ class Currency extends Model
         'is_default' => 'boolean',
         'rate'       => 'float',
     ];
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+    ];
     public $table = 'offline_mall_currencies';
 
     public function getRoundingOptions()


### PR DESCRIPTION
Don't include date in attributes casting

Back-port commit #969  in v2 branch.