### PR TITLE
"Fixing mapping issue for custom_field_values, now including image mo…

### DIFF
--- a/models/CartProduct.php
+++ b/models/CartProduct.php
@@ -133,7 +133,7 @@ class CartProduct extends Model
     public function convertCustomFieldValues()
     {
         return $this->custom_field_values
-            ->load(['custom_field', 'custom_field_option'])
+            ->load(['custom_field', 'custom_field_option', 'custom_field_option.image'])
             ->map(function (CustomFieldValue $value) {
                 $data                  = $value->toArray();
                 $data['display_value'] = $value->displayValue;


### PR DESCRIPTION
…del for proper field mapping"

This commit is addressing an issue with the converting custom field values. Specifically, it appears that the image model was not being properly mapped within this process.

The commit message indicates that the issue has been fixed, and that the image model is now included in the mapping of the custom_field_values fields. This ensures that the image data is properly handled and stored in the appropriate fields.