### PR TITLE
Change coupon code usage on cart and removing coupon codes from carts

### DIFF
--- a/classes/traits/cart/Discounts.php
+++ b/classes/traits/cart/Discounts.php
@@ -124,7 +124,7 @@ trait Discounts
                 });
 
                 if ($shippingDiscount = $this->totals()->shippingTotal()->appliedDiscount()) {
-                    $shippingDiscount['discount']->number_of_usages++;
+                    $shippingDiscount['discount']->number_of_usages--;
                     $shippingDiscount['discount']->save();
                 }
 

--- a/models/Order.php
+++ b/models/Order.php
@@ -212,8 +212,6 @@ class Order extends Model
 
             Event::fire('mall.order.afterCreate', [$order, $cart]);
 
-            $cart->updateDiscountUsageCount();
-
             $cart->delete(); // We can empty the cart once the order is created.
 
             return $order;


### PR DESCRIPTION
Currently it is possible to add coupon codes see issue #992 Coupon code can be used on multiple carts .

We have changed the usage on the shopping cart after adding the coupon code.

The coupon is removed from carts every hour once the cart is between 6-10 hours old to make sure the coupon code is ready for usage on other carts.

