### PR TITLE
Extending Orders Backend Views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 docs/.vuepress/dist
+.DS_Store

--- a/components/addressselector/address.htm
+++ b/components/addressselector/address.htm
@@ -1,4 +1,4 @@
-<div class="mall-address">
+<div class="mall-address" id="mall-address-{{ random() }}">
     <p>
         {% if address.company %}
             {{ address.company }}<br/>

--- a/components/addressselector/scripts.htm
+++ b/components/addressselector/scripts.htm
@@ -4,7 +4,7 @@
             var $body = $('body');
             $body.on('click', '.mall-address-selector--{{ __SELF__.type }} .js-change-address', function () {
                 $.request('{{ __SELF__ }}::onChangeAddress', {
-                    update: {'{{ __SELF__ }}::changeAddress': $(this).closest('.mall-address')},
+                    update: {'{{ __SELF__ }}::changeAddress': '#' + $(this).closest('.mall-address').attr('id')},
                     loading: $.oc.stripeLoadIndicator,
                 })
             });

--- a/controllers/orders/_address.htm
+++ b/controllers/orders/_address.htm
@@ -12,4 +12,5 @@
         <?= e(optional($address['state'])['name']) ?><br/>
         <?= e(optional($address['country'])['name']) ?>
     </p>
+    <?= $this->fireViewEvent('backend.Orders.extendCustomerDetails', [$order->customer_id]); ?>
 </div>

--- a/controllers/orders/_items.htm
+++ b/controllers/orders/_items.htm
@@ -27,6 +27,7 @@
     <?php foreach ($order['products'] as $item): ?>
     <tr>
         <td>
+            <?= $this->fireViewEvent('backend.orders.extendItemDetails', [$order->customer_id]); ?>
             <a href="<?= $productUpdate . '/' . e($item['product_id']); ?>">
                 <?= e($item['name']) ?><br/>
             </a>

--- a/controllers/orders/_items.htm
+++ b/controllers/orders/_items.htm
@@ -27,7 +27,7 @@
     <?php foreach ($order['products'] as $item): ?>
     <tr>
         <td>
-            <?= $this->fireViewEvent('backend.orders.extendItemDetails', [$order->customer_id]); ?>
+            <?= $this->fireViewEvent('backend.orders.extendItemDetails', [$item]); ?>
             <a href="<?= $productUpdate . '/' . e($item['product_id']); ?>">
                 <?= e($item['name']) ?><br/>
             </a>


### PR DESCRIPTION
Add two `fireViewEvent` to partials in Orders controller.
In `_items.htm` :
`<?= $this->fireViewEvent('backend.orders.extendItemDetails', [$order->customer_id]); ?>` above item name (e.g. add a thumb product)

In  `_address.htm` 
`<?= $this->fireViewEvent('backend.Orders.extendCustomerDetails', [$order->customer_id]); ?>` below address details (e.g. to display phone number attach to customer)
