### PR TITLE
Uses same Twig instance for overridden and default templates

### DIFF
--- a/classes/payments/PaymentProvider.php
+++ b/classes/payments/PaymentProvider.php
@@ -140,23 +140,23 @@ abstract class PaymentProvider
      */
     public function renderPaymentForm($cartOrOrder): string
     {
-        $templatePath = themes_path(
+        $formPartial = themes_path(
             "{$this->activeThemeCode()}/partials/mall/payments/{$this->identifier()}/{$this->paymentFormPartial()}.htm"
         );
 
-        if (! file_exists($templatePath)) {
-            $templatePath = plugins_path(
+        if (! file_exists($formPartial)) {
+            $formPartial = plugins_path(
                 "offline/mall/classes/payments/{$this->identifier()}/{$this->paymentFormPartial()}.htm"
             );
         }
 
-        if (! file_exists($templatePath)) return '';
+        if (! file_exists($formPartial)) return '';
 
         $controller = Controller::getController() ?? new Controller();
 
         $twig = $controller->getTwig();
 
-        $template = $twig->createTemplate(file_get_contents($templatePath));
+        $template = $twig->createTemplate(file_get_contents($formPartial));
 
         return $template->render(['cart' => $cartOrOrder]);
     }

--- a/classes/payments/PaymentProvider.php
+++ b/classes/payments/PaymentProvider.php
@@ -140,30 +140,24 @@ abstract class PaymentProvider
      */
     public function renderPaymentForm($cartOrOrder): string
     {
-        $override = themes_path(sprintf('%s/partials/mall/payments/%s/%s.htm',
-            $this->activeThemeCode(),
-            $this->identifier(),
-            $this->paymentFormPartial()
-        ));
+        $templatePath = themes_path(
+            "{$this->activeThemeCode()}/partials/mall/payments/{$this->identifier()}/{$this->paymentFormPartial()}.htm"
+        );
 
-        if (file_exists($override)) {
-            return (new Twig)->parse(file_get_contents($override), ['cart' => $cartOrOrder]);
+        if (! file_exists($templatePath)) {
+            $templatePath = plugins_path(
+                "offline/mall/classes/payments/{$this->identifier()}/{$this->paymentFormPartial()}.htm"
+            );
         }
 
-        $fallback = plugins_path(sprintf(
-            'offline/mall/classes/payments/%s/%s.htm',
-            $this->identifier(),
-            $this->paymentFormPartial()
-        ));
+        if (! file_exists($templatePath)) return '';
 
         $controller = Controller::getController() ?? new Controller();
+
         $twig = $controller->getTwig();
 
-        if (!file_exists($fallback)) {
-            return '';
-        }
+        $template = $twig->createTemplate(file_get_contents($templatePath));
 
-        $template = $twig->createTemplate(file_get_contents($fallback));
         return $template->render(['cart' => $cartOrOrder]);
     }
 


### PR DESCRIPTION
Hi guys, overridden and default `PaymentProvider` templates use different `Twig` instances. The overridden one cannot resolve some Twig tags like `put`. Should we use the same Twig instance for both? This should fix the #997.