### PR TITLE
Clears categories cache after reorder

### DIFF
--- a/controllers/Categories.php
+++ b/controllers/Categories.php
@@ -54,4 +54,9 @@ class Categories extends Controller
         parent::onReorder();
         (new Category())->purgeCache();
     }
+
+    public function listAfterReorder($record, $definition = null)
+    {
+        (new Category())->purgeCache();
+    }
 }


### PR DESCRIPTION
Ciao!

This PR adds the `listAfterReorder()` method to `OFFLINE\Mall\Controllers\Categories` in order to clear the cache after a reorder happens.

In the `Controllers\Categories` Mall uses the old `ReorderController` and the related `onReorder()` method to clear the categories' cache if a reorder happens. 

In OctoberCMS v3 the `ReorderController` is deprecated and we should use the `ListController` instead. The `Controller\Categories` uses the new `ListController` already, but it doesn't clear the cache after a reorder. This ends up in a 404 error if the category URL has changed. E.g. `/category/bikes/mountainbikes` to `/category/mountainbikes`.
