### PR TITLE
Add missing namespace to migration.

### DIFF
--- a/updates/add_product_variants_sort_order.php
+++ b/updates/add_product_variants_sort_order.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace OFFLINE\Mall\Updates;
   
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;


### PR DESCRIPTION
Was getting this error without the namespace:
```
Migrating Mall (OFFLINE.Mall) plugin...

   INFO  Running migrations.

  2.0.23:   Make Product variants sortable (thanks to @mjauvin) .............................................................. 1ms FAIL

In add_product_variants_sort_order.php line 5:
                                                                   
  The use statement with non-compound name 'Schema' has no effect  
```