### PR TITLE
Fix for color filter by  populate 'index_value'

### DIFF
--- a/models/PropertyValue.php
+++ b/models/PropertyValue.php
@@ -54,7 +54,7 @@ class PropertyValue extends Model
     {
         $value = $this->attributes['value'] ?? '';
         if ($this->isColor()) {
-            $value = $this->jsonDecodeValue()['name'] ?? '';
+            $value = $this->jsonDecodeValue()['hex'] ?? '';
         }
         $this->index_value = str_slug($value);
     }


### PR DESCRIPTION
Hello,

Thank you for the work done so far. It seems that there is an issue or bug related to the color property value in your code. Specifically, when you try to use the color as a filter for the products, the filter does not seem to be functioning correctly.

After analyzing the code, I have identified some potential problems that I would like to share with you. It appears that in commit [commit e8e0e80](https://github.com/OFFLINE-GmbH/oc-mall-plugin/commit/e8e0e80658d02b540b6f048873767d2d4371ac83), the "name" field for the color property value was removed. However, in the "beforeSave" function, there is an attempt to retrieve a "name" field that no longer exists.

Here is the code snippet in question:

```php
if ($this->isColor()) {
    $value = $this->jsonDecodeValue()['name'] ?? '';
}
$this->index_value = str_slug($value);
```

As a result, when the filter checkboxes are rendered, they rely on the `index_value` property, which is assigned an empty value when the "name" field is not available. Consequently, the filter for colors does not function properly.

To resolve this issue, we can make the following adjustment to the code:

```php
if ($this->isColor()) {
    $value = $this->jsonDecodeValue()['hex'] ?? '';
}
$this->index_value = str_slug($value);
```

By removing the attempt to access the non-existent "name" field and using "hex" value from the color property, we ensure that the value is properly assigned to the `$value` variable. This, in turn, ensures that the `index_value` is correctly populated with the slugified value.

Once you apply this fix, the filter checkboxes should be rendered correctly, and the color filter functionality should work as intended.