### PR TITLE
Use softDelete property for variants relation

### DIFF
--- a/classes/observers/ProductObserver.php
+++ b/classes/observers/ProductObserver.php
@@ -39,7 +39,7 @@ class ProductObserver
     public function updated(Product $product)
     {
         // If a re-index is forced skip this run, it will be triggered manually later on
-        if ($product->forceReindex) {
+        if (!$product || $product->forceReindex) {
             return;
         }
 

--- a/classes/observers/VariantObserver.php
+++ b/classes/observers/VariantObserver.php
@@ -29,7 +29,7 @@ class VariantObserver
     {
         // Skip the re-index for the backend relation updates. The re-index will
         // be triggered manually for performance reasons.
-        if ($this->isBackendRelationUpdate()) {
+        if (!$variant->product || $this->isBackendRelationUpdate()) {
             return;
         }
         (new ProductObserver($this->index))->updated($variant->product);

--- a/models/Product.php
+++ b/models/Product.php
@@ -164,7 +164,7 @@ class Product extends Model
     ];
     public $hasMany = [
         'prices'                 => [ProductPrice::class, 'conditions' => 'variant_id is null'],
-        'variants'               => Variant::class,
+        'variants'               => [Variant::class, 'softDelete' => true],
         'cart_products'          => CartProduct::class,
         'order_products'         => OrderProduct::class,
         'image_sets'             => ImageSet::class,
@@ -315,7 +315,6 @@ class Product extends Model
     {
         $this->prices()->delete();
         $this->additional_prices()->delete();
-        $this->variants()->delete();
         $this->property_values()->delete();
         DB::table('offline_mall_product_accessory')->where('product_id', $this->id)->delete();
         DB::table('offline_mall_product_tax')->where('product_id', $this->id)->delete();


### PR DESCRIPTION
The `softDelete` relation property will make sure the related records are properly deleted/restored when deleting the parent record.

ref. Database/Traits/SoftDelete.php trait