### PR TITLE
Support DomPDF 2.x / Support Laravel 10

### DIFF
--- a/classes/registration/BootServiceContainer.php
+++ b/classes/registration/BootServiceContainer.php
@@ -92,7 +92,7 @@ trait BootServiceContainer
         AliasLoader::getInstance()->alias('PDF', Facade::class);
 
         $this->app->bind('dompdf.options', function () {
-            if ($defines = $this->app['config']->get('offline.mall::pdf.options')) {
+            if ($defines = $this->app['config']->get('offline.mall::pdf.defines')) {
                 $options = [];
                 foreach ($defines as $key => $value) {
                     $key           = strtolower(str_replace('DOMPDF_', '', $key));

--- a/classes/registration/BootServiceContainer.php
+++ b/classes/registration/BootServiceContainer.php
@@ -92,7 +92,7 @@ trait BootServiceContainer
         AliasLoader::getInstance()->alias('PDF', Facade::class);
 
         $this->app->bind('dompdf.options', function () {
-            if ($defines = $this->app['config']->get('offline.mall::pdf.defines')) {
+            if ($defines = $this->app['config']->get('offline.mall::pdf.options')) {
                 $options = [];
                 foreach ($defines as $key => $value) {
                     $key           = strtolower(str_replace('DOMPDF_', '', $key));

--- a/classes/traits/PDFMaker.php
+++ b/classes/traits/PDFMaker.php
@@ -4,9 +4,9 @@
 namespace OFFLINE\Mall\Classes\Traits;
 
 
+use Barryvdh\DomPDF\Facade\Pdf;
 use Cms\Classes\CmsException;
 use Cms\Classes\Controller;
-use PDF;
 
 trait PDFMaker
 {
@@ -53,7 +53,7 @@ trait PDFMaker
      */
     public function makePDFFromString(string $contents)
     {
-        return PDF::loadHTML($contents);
+        return Pdf::loadHTML($contents);
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "league/omnipay": "^3.2",
     "omnipay/paypal": "^3.0",
     "omnipay/stripe": "^3.0",
-    "barryvdh/laravel-dompdf": "^2.0",
+    "barryvdh/laravel-dompdf": "^0.9|^1.0|^2.0",
     "rainlab/user-plugin": "^1.6|^2.0",
     "rainlab/location-plugin": "^1.1.5",
     "rainlab/translate-plugin": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "league/omnipay": "^3.2",
     "omnipay/paypal": "^3.0",
     "omnipay/stripe": "^3.0",
-    "barryvdh/laravel-dompdf": "^0.9|^1.0",
+    "barryvdh/laravel-dompdf": "^2.0",
     "rainlab/user-plugin": "^1.6|^2.0",
     "rainlab/location-plugin": "^1.1.5",
     "rainlab/translate-plugin": "^2.0"

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -4,7 +4,7 @@
 return [
     'show_warnings' => false,
     'orientation'   => 'portrait',
-    'defines'       => [
+    'options'       => [
         'font_dir'               => storage_path('fonts/'),
         'font_cache'             => storage_path('fonts/'),
         'temp_dir'               => sys_get_temp_dir(),


### PR DESCRIPTION
While trying out Laravel 10 I found out that we need [`barryvdh/laravel-dompdf:2.0.1`](https://github.com/barryvdh/laravel-dompdf/releases/tag/v2.0.1)

This PR sets `barryvdh/laravel-dompdf` to `^2.0` and updates [deprecations](https://github.com/barryvdh/laravel-dompdf/releases/tag/v2.0.0).