### PR TITLE
Update integration with Tailor for sitemap generation

### DIFF
--- a/classes/registration/BootEvents.php
+++ b/classes/registration/BootEvents.php
@@ -57,6 +57,15 @@ trait BootEvents
             ];
         });
 
+        Event::listen('cms.pageLookup.listTypes', function() {
+            return [
+                'mall-category'       => '[OFFLINE.Mall] ' . trans('offline.mall::lang.menu_items.single_category'),
+                'all-mall-categories' => '[OFFLINE.Mall] ' . trans('offline.mall::lang.menu_items.all_categories'),
+                'all-mall-products'   => '[OFFLINE.Mall] ' . trans('offline.mall::lang.menu_items.all_products'),
+                'all-mall-variants'   => '[OFFLINE.Mall] ' . trans('offline.mall::lang.menu_items.all_variants'),
+            ];
+        });
+
         Event::listen('pages.menuitem.getTypeInfo', function ($type) {
             if ($type === 'all-mall-categories' || $type === 'mall-category') {
                 return Category::getMenuTypeInfo($type);
@@ -68,7 +77,33 @@ trait BootEvents
             }
         });
 
+        Event::listen('cms.pageLookup.getTypeInfo', function($type) {
+            if ($type === 'all-mall-categories' || $type === 'mall-category') {
+                return Category::getMenuTypeInfo($type);
+            }
+            if ($type === 'all-mall-products' || $type === 'all-mall-variants') {
+                return [
+                    'dynamicItems' => true,
+                ];
+            }
+        });
+
         Event::listen('pages.menuitem.resolveItem', function ($type, $item, $url, $theme) {
+            if ($type === 'all-mall-categories') {
+                return Category::resolveCategoriesItem($item, $url, $theme);
+            }
+            if ($type === 'mall-category') {
+                return Category::resolveCategoryItem($item, $url, $theme);
+            }
+            if ($type === 'all-mall-products') {
+                return Product::resolveItem($item, $url, $theme);
+            }
+            if ($type === 'all-mall-variants') {
+                return Variant::resolveItem($item, $url, $theme);
+            }
+        });
+
+        Event::listen('cms.pageLookup.resolveItem', function($type, $item, $url, $theme) {
             if ($type === 'all-mall-categories') {
                 return Category::resolveCategoriesItem($item, $url, $theme);
             }


### PR DESCRIPTION
As the Rainlab.Sitemap plugin seems to be no longer until active development and based on their upgrade guide there is a way to generate sitemaps with the new [page finder widget](https://github.com/rainlab/sitemap-plugin/blob/master/UPGRADE.md) as of 3.2 as per the upgrade [guide](https://github.com/rainlab/sitemap-plugin/blob/master/UPGRADE.md). I would add required event listeners to enable the same functionality as for the previous sitemap plugin - eg. selecting all categories, products, etc. 

I am not completely sure whether that is all that is needed but as Mall was already integrated with sitemap I do not think there is more to it but feel free to correct me. 

Thank you