### PR TITLE
Ensure '0' values are not filtered out in array_filter function

### DIFF
--- a/classes/index/ProductEntry.php
+++ b/classes/index/ProductEntry.php
@@ -90,7 +90,9 @@ class ProductEntry implements Entry
         }
 
         return $input->groupBy('property_id')->map(function ($value) {
-            return $value->pluck('index_value')->unique()->filter()->values();
+            return $value->pluck('index_value')->unique()->filter(function ($item) {
+                return ! empty($item) || $item === 0;
+            })->values();
         })->filter();
     }
 }

--- a/classes/index/ProductEntry.php
+++ b/classes/index/ProductEntry.php
@@ -91,7 +91,7 @@ class ProductEntry implements Entry
 
         return $input->groupBy('property_id')->map(function ($value) {
             return $value->pluck('index_value')->unique()->filter(function ($item) {
-                return ! empty($item) || $item === 0;
+                 return !empty($item) || $item === 0 || $item === '0';
             })->values();
         })->filter();
     }

--- a/classes/index/VariantEntry.php
+++ b/classes/index/VariantEntry.php
@@ -99,7 +99,7 @@ class VariantEntry implements Entry
 
         return $input->groupBy('property_id')->map(function ($value) {
             return $value->pluck('index_value')->unique()->filter(function ($item) {
-                return ! empty($item) || $item === 0;
+                return ! empty($item) || $item === 0 || $item === '0';
             })->values();
         })->filter();
     }

--- a/classes/index/VariantEntry.php
+++ b/classes/index/VariantEntry.php
@@ -98,7 +98,9 @@ class VariantEntry implements Entry
         }
 
         return $input->groupBy('property_id')->map(function ($value) {
-            return $value->pluck('index_value')->unique()->filter()->values();
+            return $value->pluck('index_value')->unique()->filter(function ($item) {
+                return ! empty($item) || $item === 0;
+            })->values();
         })->filter();
     }
 }

--- a/components/ProductsFilter.php
+++ b/components/ProductsFilter.php
@@ -358,7 +358,7 @@ class ProductsFilter extends MallComponent
             }
 
             // Remove empty set values
-            $values = array_filter(array_wrap($values));
+            $values = array_filter(array_wrap($values), 'strlen'));
 
             return count($values) ? [$id => new SetFilter($property, $values)] : [];
         });


### PR DESCRIPTION
This pull request addresses an issue where '0' values were being inadvertently filtered out in the array_filter function. By adding the strlen callback to the array_filter call, '0' values are now retained in the resulting array. This change ensures consistent behavior and prevents unintentional data loss when dealing with propertyvalues containing '0' values.