### PR TITLE
Allow extendind Signup messages

### DIFF
--- a/classes/customer/DefaultSignUpHandler.php
+++ b/classes/customer/DefaultSignUpHandler.php
@@ -212,7 +212,7 @@ class DefaultSignUpHandler implements SignUpHandler
 
     public static function messages(): array
     {
-        return [
+        $messages = [
             'email.required'          => trans('offline.mall::lang.components.signup.errors.email.required'),
             'email.email'             => trans('offline.mall::lang.components.signup.errors.email.email'),
             'email.unique'            => trans('offline.mall::lang.components.signup.errors.email.unique'),
@@ -242,5 +242,9 @@ class DefaultSignUpHandler implements SignUpHandler
 
             'terms_accepted.required' => trans('offline.mall::lang.components.signup.errors.terms_accepted.required'),
         ];
+
+        Event::fire('mall.customer.extendSignupMessages', [&$messages]);
+
+        return $messages;
     }
 }

--- a/docs/development/events.md
+++ b/docs/development/events.md
@@ -30,6 +30,14 @@ An order has been marked as shipped. This event receives the shipped `$order` as
 
 ## Customer
 
+### `mall.customer.extendSignupRules`
+
+This event is emitted before validating a new customer account. This event receives a reference to the validator rules.
+
+### `mall.customer.extendSignupMessages`
+
+This event is emitted before validating a new customer account. This event receives a reference to the validator messages.
+
 ### `mall.customer.beforeSignup`
 
 This event is emitted before a new customer account is created. This event receives the `SignupHandler` implementation 


### PR DESCRIPTION
This PR allow developers to extend the validation messages when a customer signup.  
It is currently possible to add/extend validator rules, but not the associated messages.

This can be added to V3 branch without creating any breaking changes.