### PR TITLE
Don't hide fields when is_virtual

### DIFF
--- a/models/Product.php
+++ b/models/Product.php
@@ -688,12 +688,7 @@ class Product extends Model
         }
 
         if ($this->is_virtual) {
-            $this->hideField($fields, 'inventory_management_method');
-            $this->hideField($fields, 'variants');
             $this->hideField($fields, 'weight');
-            if ($this->files->count() > 0) {
-                $fields->missing_file_hint->hidden = true;
-            }
         } else {
             $this->hideField($fields, 'product_files');
             $this->hideField($fields, 'missing_file_hint');


### PR DESCRIPTION
Don't hide inventory_management_method, variants and missing_file_hint when is_virtual is flagged.