### PR TITLE
Don't hide variant fields when is_virtual is selected

### DIFF
--- a/models/Product.php
+++ b/models/Product.php
@@ -688,12 +688,7 @@ class Product extends Model
         }
 
         if ($this->is_virtual) {
-            $this->hideField($fields, 'inventory_management_method');
-            $this->hideField($fields, 'variants');
             $this->hideField($fields, 'weight');
-            if ($this->files->count() > 0) {
-                $fields->missing_file_hint->hidden = true;
-            }
         } else {
             $this->hideField($fields, 'product_files');
             $this->hideField($fields, 'missing_file_hint');

--- a/models/product/fields_create.yaml
+++ b/models/product/fields_create.yaml
@@ -38,10 +38,6 @@ tabs:
             span: right
             type: dropdown
             tab: 'offline.mall::lang.product.general'
-            trigger:
-                action: hide
-                field: is_virtual
-                condition: 'checked'
         stock:
             label: 'offline.mall::lang.product.stock'
             oc.commentPosition: ''

--- a/models/product/fields_edit.yaml
+++ b/models/product/fields_edit.yaml
@@ -52,10 +52,6 @@ tabs:
             span: left
             type: dropdown
             tab: 'offline.mall::lang.product.general'
-            trigger:
-                action: hide
-                field: is_virtual
-                condition: 'checked'
         group_by_property_id:
             label: 'offline.mall::lang.product.group_by_property'
             oc.commentPosition: ''
@@ -120,10 +116,6 @@ tabs:
         variants:
             span: full
             path: variants
-            trigger:
-                action: hide
-                field: inventory_management_method
-                condition: 'value[single]'
             type: partial
             tab: 'offline.mall::lang.product.general'
             dependsOn: categories


### PR DESCRIPTION
Hi, 

As discussed in issue [600](https://github.com/OFFLINE-GmbH/oc-mall-plugin/issues/600) I would like to allow variants even when a product is_virtual.

Usecases for this would be for example a membership with three tiers, or an event with several ticket options.

Could you kindly consider reviewing this pull request?

Best regards,

M