### PR TITLE
Update BootEvents.php

### DIFF
--- a/classes/registration/BootEvents.php
+++ b/classes/registration/BootEvents.php
@@ -104,6 +104,16 @@ trait BootEvents
                 return Product::translateParams($params, $oldLocale, $newLocale);
             }
         });
+
+        // Translate slugs October 3 CMS
+        Event::listen('cms.sitePicker.overrideParams', function ($page, $params, $currentSite, $proposedSite) {
+            if ($page->getBaseFileName() === GeneralSettings::get('category_page')) {
+                return Category::translateParams($params, $currentSite->hard_locale, $proposedSite->hard_locale);
+            }
+            if ($page->getBaseFileName() === GeneralSettings::get('product_page')) {
+                return Product::translateParams($params, $currentSite->hard_locale, $proposedSite->hard_locale);
+            }
+        });
     }
 
     protected function registerSiteSearchEvents()


### PR DESCRIPTION
For OctoberCMS 3 there is a new event used for listen to translated pages. See [cms.sitePicker.overrideParams](https://octobercms.com/docs/api/cms/sitepicker/overrideparams) and the [Upgrading from Translate v1 to v2](https://github.com/rainlab/translate-plugin/blob/master/UPGRADE.md#events-updated) documentation.