### PR TITLE
Optimise unique property values query

### DIFF
--- a/classes/jobs/UpdateUniquePropertyForCategory.php
+++ b/classes/jobs/UpdateUniquePropertyForCategory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OFFLINE\Mall\Classes\Jobs;
+
+use OFFLINE\Mall\Models\Category;
+use Illuminate\Contracts\Queue\Job;
+use OFFLINE\Mall\Models\UniquePropertyValue;
+
+class UpdateUniquePropertyForCategory
+{
+    public function fire(Job $job, $data)
+    {
+        $category = Category::find($data['id']);
+
+        UniquePropertyValue::resetForCategory($category);
+
+        $job->delete();
+    }
+}

--- a/classes/jobs/UpdateUniquePropertyForCategory.php
+++ b/classes/jobs/UpdateUniquePropertyForCategory.php
@@ -2,6 +2,7 @@
 
 namespace OFFLINE\Mall\Classes\Jobs;
 
+use Cache;
 use OFFLINE\Mall\Models\Category;
 use Illuminate\Contracts\Queue\Job;
 use OFFLINE\Mall\Models\UniquePropertyValue;
@@ -11,6 +12,8 @@ class UpdateUniquePropertyForCategory
     public function fire(Job $job, $data)
     {
         $category = Category::find($data['id']);
+
+        Cache::forget(UniquePropertyValue::getCacheKeyForCategory($category));
 
         UniquePropertyValue::resetForCategory($category);
 

--- a/classes/queries/UniquePropertyValuesInCategoriesQuery.php
+++ b/classes/queries/UniquePropertyValuesInCategoriesQuery.php
@@ -5,11 +5,15 @@ namespace OFFLINE\Mall\Classes\Queries;
 use DB;
 use Illuminate\Support\Collection;
 use October\Rain\Database\QueryBuilder;
+use OFFLINE\Mall\Models\UniquePropertyValue;
 
 /**
  * This query is used to get a list of all unique property values in one or
  * more categories. It is used to display a set of possible filters
  * for all available property values.
+ *
+ * @deprecated 3.4.0 use UniquePropertyValue model with category relation
+ *
  */
 class UniquePropertyValuesInCategoriesQuery
 {
@@ -31,9 +35,11 @@ class UniquePropertyValuesInCategoriesQuery
      */
     public function query()
     {
+        return UniquePropertyValue::whereIn('category_id', $this->categories->pluck('id'));
         return DB
             ::table('offline_mall_products')
-            ->selectRaw('
+            ->selectRaw(
+                '
                 MIN(offline_mall_property_values.id) AS id,
                 offline_mall_property_values.value,
                 offline_mall_property_values.index_value,
@@ -42,7 +48,7 @@ class UniquePropertyValuesInCategoriesQuery
             ->where(function ($q) {
                 $q->where(function ($q) {
                     $q->where('offline_mall_products.published', true)
-                      ->whereNull('offline_mall_product_variants.id');
+                        ->whereNull('offline_mall_product_variants.id');
                 })->orWhere('offline_mall_product_variants.published', true);
             })
             ->whereIn('offline_mall_category_product.category_id', $this->categories->pluck('id'))

--- a/classes/queries/UniquePropertyValuesInCategoriesQuery.php
+++ b/classes/queries/UniquePropertyValuesInCategoriesQuery.php
@@ -37,8 +37,7 @@ class UniquePropertyValuesInCategoriesQuery
     {
         return DB
             ::table('offline_mall_products')
-            ->selectRaw(
-                '
+            ->selectRaw('
                 MIN(offline_mall_property_values.id) AS id,
                 offline_mall_property_values.value,
                 offline_mall_property_values.index_value,
@@ -47,7 +46,7 @@ class UniquePropertyValuesInCategoriesQuery
             ->where(function ($q) {
                 $q->where(function ($q) {
                     $q->where('offline_mall_products.published', true)
-                        ->whereNull('offline_mall_product_variants.id');
+                      ->whereNull('offline_mall_product_variants.id');
                 })->orWhere('offline_mall_product_variants.published', true);
             })
             ->whereIn('offline_mall_category_product.category_id', $this->categories->pluck('id'))

--- a/classes/queries/UniquePropertyValuesInCategoriesQuery.php
+++ b/classes/queries/UniquePropertyValuesInCategoriesQuery.php
@@ -11,7 +11,7 @@ use October\Rain\Database\QueryBuilder;
  * more categories. It is used to display a set of possible filters
  * for all available property values.
  *
- * @deprecated 3.4.0 use UniquePropertyValue::getForMultipleCategories($categories)
+ * @deprecated 3.4.0 use UniquePropertyValue::hydratePropertyValuesForCategories($categories)
  * @see \OFFLINE\Mall\Models\UniquePropertyValue
  *
  */

--- a/classes/queries/UniquePropertyValuesInCategoriesQuery.php
+++ b/classes/queries/UniquePropertyValuesInCategoriesQuery.php
@@ -5,14 +5,14 @@ namespace OFFLINE\Mall\Classes\Queries;
 use DB;
 use Illuminate\Support\Collection;
 use October\Rain\Database\QueryBuilder;
-use OFFLINE\Mall\Models\UniquePropertyValue;
 
 /**
  * This query is used to get a list of all unique property values in one or
  * more categories. It is used to display a set of possible filters
  * for all available property values.
  *
- * @deprecated 3.4.0 use UniquePropertyValue model with category relation
+ * @deprecated 3.4.0 use UniquePropertyValue::getForMultipleCategories($categories)
+ * @see \OFFLINE\Mall\Models\UniquePropertyValue
  *
  */
 class UniquePropertyValuesInCategoriesQuery
@@ -35,7 +35,6 @@ class UniquePropertyValuesInCategoriesQuery
      */
     public function query()
     {
-        return UniquePropertyValue::whereIn('category_id', $this->categories->pluck('id'));
         return DB
             ::table('offline_mall_products')
             ->selectRaw(

--- a/classes/registration/BootEvents.php
+++ b/classes/registration/BootEvents.php
@@ -21,7 +21,7 @@ trait BootEvents
 {
     protected function registerEvents()
     {
-        // $this->registerObservers();
+        $this->registerObservers();
         $this->registerGenericEvents();
         $this->registerStaticPagesEvents();
         $this->registerSiteSearchEvents();

--- a/classes/registration/BootEvents.php
+++ b/classes/registration/BootEvents.php
@@ -21,7 +21,7 @@ trait BootEvents
 {
     protected function registerEvents()
     {
-        $this->registerObservers();
+        // $this->registerObservers();
         $this->registerGenericEvents();
         $this->registerStaticPagesEvents();
         $this->registerSiteSearchEvents();

--- a/models/Category.php
+++ b/models/Category.php
@@ -187,6 +187,18 @@ class Category extends Model
                        Queue::push(PropertyRemovalUpdate::class, $data);
                    });
         });
+
+        $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {
+            if ($relationName === 'property_groups') {
+                UniquePropertyValue::updateUsingCategory($this);
+            }
+        });
+
+        $this->bindEvent('model.relation.detach', function ($relationName, $detachedIdList) {
+            if ($relationName === 'property_groups') {
+                UniquePropertyValue::updateUsingCategory($this);
+            }
+        });
     }
 
     /**

--- a/models/Category.php
+++ b/models/Category.php
@@ -1,24 +1,21 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use DB;
 use Model;
-use System\Models\File;
-use October\Rain\Support\Collection;
 use Illuminate\Support\Facades\Queue;
 use October\Rain\Database\Traits\NestedTree;
 use October\Rain\Database\Traits\SoftDelete;
 use October\Rain\Database\Traits\Validation;
-use OFFLINE\Mall\Models\UniquePropertyValue;
-use OFFLINE\Mall\Classes\Traits\Category\Slug;
-use OFFLINE\Mall\Classes\Traits\SortableRelation;
-use OFFLINE\Mall\Classes\Traits\Category\MenuItems;
+use October\Rain\Support\Collection;
 use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
+use OFFLINE\Mall\Classes\Traits\Category\MenuItems;
 use OFFLINE\Mall\Classes\Traits\Category\Properties;
+use OFFLINE\Mall\Classes\Traits\Category\Slug;
 use OFFLINE\Mall\Classes\Traits\Category\Translation;
+use OFFLINE\Mall\Classes\Traits\SortableRelation;
+use System\Models\File;
 
 class Category extends Model
 {
@@ -169,26 +166,26 @@ class Category extends Model
 
             // Fetch all child categories that inherit this categories properties.
             $categories = $this->scopeAllChildren(self::newQuery())
-                ->where('inherit_property_groups', true)
-                ->get()
-                ->concat([$this]);
+                               ->where('inherit_property_groups', true)
+                               ->get()
+                               ->concat([$this]);
 
             // Chunk the deletion and re-indexing since a lot of products and variants
             // might be affected by this change.
             Product::published()
-                ->orderBy('id')
-                ->whereHas('categories', function ($q) use ($categories) {
-                    $q->whereIn('category_id', $categories->pluck('id'));
-                })
-                ->with('variants')
-                ->chunk(25, function ($products) use ($properties) {
-                    $data = [
-                        'properties' => $properties,
-                        'products'   => $products->pluck('id'),
-                        'variants'   => $products->flatMap->variants->pluck('id'),
-                    ];
-                    Queue::push(PropertyRemovalUpdate::class, $data);
-                });
+                   ->orderBy('id')
+                   ->whereHas('categories', function ($q) use ($categories) {
+                       $q->whereIn('category_id', $categories->pluck('id'));
+                   })
+                   ->with('variants')
+                   ->chunk(25, function ($products) use ($properties) {
+                       $data = [
+                           'properties' => $properties,
+                           'products'   => $products->pluck('id'),
+                           'variants'   => $products->flatMap->variants->pluck('id'),
+                       ];
+                       Queue::push(PropertyRemovalUpdate::class, $data);
+                   });
         });
     }
 
@@ -212,7 +209,7 @@ class Category extends Model
             if ($model->inherit_review_categories === true && $model->review_categories()->count() > 0) {
                 $model->review_categories()->detach();
             }
-            if (!$model->slug) {
+            if ( ! $model->slug) {
                 $model->slug = str_slug($model->name);
             }
         });
@@ -257,9 +254,9 @@ class Category extends Model
         $items = $this->id ? Category::withoutSelf()->get() : Category::getAll();
 
         return [
-            // null key for "no parent"
-            null => '(' . trans('offline.mall::lang.category.no_parent') . ')',
-        ] + $items->listsNested('name', 'id');
+                // null key for "no parent"
+                null => '(' . trans('offline.mall::lang.category.no_parent') . ')',
+            ] + $items->listsNested('name', 'id');
     }
 
     /**
@@ -297,7 +294,7 @@ class Category extends Model
     public function getInheritedReviewCategories()
     {
         $groups = $this->getParents()->first(function (Category $category) {
-            return !$category->inherit_review_categories;
+            return ! $category->inherit_review_categories;
         })->review_categories;
 
         return $groups ?? new Collection();

--- a/models/Category.php
+++ b/models/Category.php
@@ -282,6 +282,11 @@ class Category extends Model
         return $this->inherit_review_categories ? $this->getInheritedReviewCategories() : $this->review_categories;
     }
 
+    public function afterSave(): void
+    {
+        UniquePropertyValue::updateUsingCategory($this);
+    }
+
     /**
      * Returns the review categories of the first parent
      * that does not inherit them.

--- a/models/Category.php
+++ b/models/Category.php
@@ -1,21 +1,24 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use DB;
 use Model;
+use System\Models\File;
+use October\Rain\Support\Collection;
 use Illuminate\Support\Facades\Queue;
 use October\Rain\Database\Traits\NestedTree;
 use October\Rain\Database\Traits\SoftDelete;
 use October\Rain\Database\Traits\Validation;
-use October\Rain\Support\Collection;
-use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
-use OFFLINE\Mall\Classes\Traits\Category\MenuItems;
-use OFFLINE\Mall\Classes\Traits\Category\Properties;
+use OFFLINE\Mall\Models\UniquePropertyValue;
 use OFFLINE\Mall\Classes\Traits\Category\Slug;
-use OFFLINE\Mall\Classes\Traits\Category\Translation;
 use OFFLINE\Mall\Classes\Traits\SortableRelation;
-use System\Models\File;
+use OFFLINE\Mall\Classes\Traits\Category\MenuItems;
+use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
+use OFFLINE\Mall\Classes\Traits\Category\Properties;
+use OFFLINE\Mall\Classes\Traits\Category\Translation;
 
 class Category extends Model
 {
@@ -166,26 +169,26 @@ class Category extends Model
 
             // Fetch all child categories that inherit this categories properties.
             $categories = $this->scopeAllChildren(self::newQuery())
-                               ->where('inherit_property_groups', true)
-                               ->get()
-                               ->concat([$this]);
+                ->where('inherit_property_groups', true)
+                ->get()
+                ->concat([$this]);
 
             // Chunk the deletion and re-indexing since a lot of products and variants
             // might be affected by this change.
             Product::published()
-                   ->orderBy('id')
-                   ->whereHas('categories', function ($q) use ($categories) {
-                       $q->whereIn('category_id', $categories->pluck('id'));
-                   })
-                   ->with('variants')
-                   ->chunk(25, function ($products) use ($properties) {
-                       $data = [
-                           'properties' => $properties,
-                           'products'   => $products->pluck('id'),
-                           'variants'   => $products->flatMap->variants->pluck('id'),
-                       ];
-                       Queue::push(PropertyRemovalUpdate::class, $data);
-                   });
+                ->orderBy('id')
+                ->whereHas('categories', function ($q) use ($categories) {
+                    $q->whereIn('category_id', $categories->pluck('id'));
+                })
+                ->with('variants')
+                ->chunk(25, function ($products) use ($properties) {
+                    $data = [
+                        'properties' => $properties,
+                        'products'   => $products->pluck('id'),
+                        'variants'   => $products->flatMap->variants->pluck('id'),
+                    ];
+                    Queue::push(PropertyRemovalUpdate::class, $data);
+                });
         });
     }
 
@@ -209,7 +212,7 @@ class Category extends Model
             if ($model->inherit_review_categories === true && $model->review_categories()->count() > 0) {
                 $model->review_categories()->detach();
             }
-            if ( ! $model->slug) {
+            if (!$model->slug) {
                 $model->slug = str_slug($model->name);
             }
         });
@@ -254,9 +257,9 @@ class Category extends Model
         $items = $this->id ? Category::withoutSelf()->get() : Category::getAll();
 
         return [
-                // null key for "no parent"
-                null => '(' . trans('offline.mall::lang.category.no_parent') . ')',
-            ] + $items->listsNested('name', 'id');
+            // null key for "no parent"
+            null => '(' . trans('offline.mall::lang.category.no_parent') . ')',
+        ] + $items->listsNested('name', 'id');
     }
 
     /**
@@ -294,7 +297,7 @@ class Category extends Model
     public function getInheritedReviewCategories()
     {
         $groups = $this->getParents()->first(function (Category $category) {
-            return ! $category->inherit_review_categories;
+            return !$category->inherit_review_categories;
         })->review_categories;
 
         return $groups ?? new Collection();

--- a/models/Product.php
+++ b/models/Product.php
@@ -342,6 +342,24 @@ class Product extends Model
         $this->bindEvent('model.relation.beforeDetach', function ($relationName, $attachedIdList) {
             $this->forceReindex = true;
         });
+
+        $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {
+            if ($relationName === 'categories') {
+                foreach ($attachedIdList as $attachedId) {
+                    $category = Category::find($attachedId);
+                    UniquePropertyValue::updateUsingCategory($category);
+                }
+            }
+        });
+
+        $this->bindEvent('model.relation.detach', function ($relationName, $detachedIdList) {
+            if ($relationName === 'categories') {
+                foreach ($detachedIdList as $detachedId) {
+                    $category = Category::find($detachedId);
+                    UniquePropertyValue::updateUsingCategory($category);
+                }
+            }
+        });
     }
 
     /**
@@ -393,8 +411,6 @@ class Product extends Model
                 ->whereIn('property_id', $properties)
                 ->delete();
         }
-
-        UniquePropertyValue::updateUsingProduct($this);
 
         if ($this->forceReindex) {
             $this->forceReindex = false;

--- a/models/Product.php
+++ b/models/Product.php
@@ -2,30 +2,29 @@
 
 namespace OFFLINE\Mall\Models;
 
-use DB;
 use Cache;
+use DB;
 use Model;
-use Queue;
 use Cms\Classes\Page;
-use System\Models\File;
-use October\Rain\Support\Collection;
-use OFFLINE\Mall\Classes\Index\Index;
-use OFFLINE\Mall\Classes\Traits\Images;
-use OFFLINE\Mall\Classes\Traits\HashIds;
-use OFFLINE\Mall\Classes\Traits\PDFMaker;
+use October\Rain\Database\Models\DeferredBinding;
 use October\Rain\Database\Traits\Nullable;
 use October\Rain\Database\Traits\Sluggable;
 use October\Rain\Database\Traits\SoftDelete;
 use October\Rain\Database\Traits\Validation;
+use October\Rain\Support\Collection;
+use OFFLINE\Mall\Classes\Index\Index;
+use OFFLINE\Mall\Classes\Observers\ProductObserver;
 use OFFLINE\Mall\Classes\Traits\CustomFields;
 use OFFLINE\Mall\Classes\Traits\FilteredTaxes;
+use OFFLINE\Mall\Classes\Traits\HashIds;
+use OFFLINE\Mall\Classes\Traits\Images;
 use OFFLINE\Mall\Classes\Traits\PriceAccessors;
+use OFFLINE\Mall\Classes\Traits\ProductPriceAccessors;
 use OFFLINE\Mall\Classes\Traits\PropertyValues;
-use October\Rain\Database\Models\DeferredBinding;
 use OFFLINE\Mall\Classes\Traits\StockAndQuantity;
 use OFFLINE\Mall\Classes\Traits\UserSpecificPrice;
-use OFFLINE\Mall\Classes\Observers\ProductObserver;
-use OFFLINE\Mall\Classes\Traits\ProductPriceAccessors;
+use OFFLINE\Mall\Classes\Traits\PDFMaker;
+use System\Models\File;
 
 class Product extends Model
 {
@@ -97,12 +96,12 @@ class Product extends Model
 
     /**
      * Attribute names that are json encoded and decoded from the database.
-     * @var array
+     * @var array 
      */
     public $jsonable = [
-        'links',
-        'additional_descriptions',
-        'additional_properties',
+        'links', 
+        'additional_descriptions', 
+        'additional_properties', 
         'embeds'
     ];
 
@@ -158,7 +157,7 @@ class Product extends Model
      * The attributes that should be cast.
      * @var array
      */
-    public $casts = [
+    public $casts = [   
         'price_includes_tax'            => 'boolean',
         'allow_out_of_stock_purchases'  => 'boolean',
         'weight'                        => 'integer',
@@ -185,13 +184,13 @@ class Product extends Model
     public $slugs = [
         'slug' => 'name',
     ];
-
+    
     /**
      * The accessors to append to the model's array form.
      * @var array
      */
     public $appends = ['hash_id'];
-
+    
     /**
      * The attachMany relationships of this model.
      * @var array

--- a/models/Product.php
+++ b/models/Product.php
@@ -96,12 +96,12 @@ class Product extends Model
 
     /**
      * Attribute names that are json encoded and decoded from the database.
-     * @var array 
+     * @var array
      */
     public $jsonable = [
-        'links', 
-        'additional_descriptions', 
-        'additional_properties', 
+        'links',
+        'additional_descriptions',
+        'additional_properties',
         'embeds'
     ];
 
@@ -157,7 +157,7 @@ class Product extends Model
      * The attributes that should be cast.
      * @var array
      */
-    public $casts = [   
+    public $casts = [
         'price_includes_tax'            => 'boolean',
         'allow_out_of_stock_purchases'  => 'boolean',
         'weight'                        => 'integer',
@@ -184,13 +184,13 @@ class Product extends Model
     public $slugs = [
         'slug' => 'name',
     ];
-    
+
     /**
      * The accessors to append to the model's array form.
      * @var array
      */
     public $appends = ['hash_id'];
-    
+
     /**
      * The attachMany relationships of this model.
      * @var array
@@ -393,6 +393,8 @@ class Product extends Model
                 ->whereIn('property_id', $properties)
                 ->delete();
         }
+
+        UniquePropertyValue::updateUsingProduct($this);
 
         if ($this->forceReindex) {
             $this->forceReindex = false;

--- a/models/Product.php
+++ b/models/Product.php
@@ -2,29 +2,30 @@
 
 namespace OFFLINE\Mall\Models;
 
-use Cache;
 use DB;
+use Cache;
 use Model;
+use Queue;
 use Cms\Classes\Page;
-use October\Rain\Database\Models\DeferredBinding;
+use System\Models\File;
+use October\Rain\Support\Collection;
+use OFFLINE\Mall\Classes\Index\Index;
+use OFFLINE\Mall\Classes\Traits\Images;
+use OFFLINE\Mall\Classes\Traits\HashIds;
+use OFFLINE\Mall\Classes\Traits\PDFMaker;
 use October\Rain\Database\Traits\Nullable;
 use October\Rain\Database\Traits\Sluggable;
 use October\Rain\Database\Traits\SoftDelete;
 use October\Rain\Database\Traits\Validation;
-use October\Rain\Support\Collection;
-use OFFLINE\Mall\Classes\Index\Index;
-use OFFLINE\Mall\Classes\Observers\ProductObserver;
 use OFFLINE\Mall\Classes\Traits\CustomFields;
 use OFFLINE\Mall\Classes\Traits\FilteredTaxes;
-use OFFLINE\Mall\Classes\Traits\HashIds;
-use OFFLINE\Mall\Classes\Traits\Images;
 use OFFLINE\Mall\Classes\Traits\PriceAccessors;
-use OFFLINE\Mall\Classes\Traits\ProductPriceAccessors;
 use OFFLINE\Mall\Classes\Traits\PropertyValues;
+use October\Rain\Database\Models\DeferredBinding;
 use OFFLINE\Mall\Classes\Traits\StockAndQuantity;
 use OFFLINE\Mall\Classes\Traits\UserSpecificPrice;
-use OFFLINE\Mall\Classes\Traits\PDFMaker;
-use System\Models\File;
+use OFFLINE\Mall\Classes\Observers\ProductObserver;
+use OFFLINE\Mall\Classes\Traits\ProductPriceAccessors;
 
 class Product extends Model
 {

--- a/models/Property.php
+++ b/models/Property.php
@@ -1,16 +1,15 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use Model;
 use Illuminate\Support\Facades\Queue;
-use OFFLINE\Mall\Classes\Traits\HashIds;
 use October\Rain\Database\Traits\Sluggable;
 use October\Rain\Database\Traits\SoftDelete;
 use October\Rain\Database\Traits\Validation;
 use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
+use OFFLINE\Mall\Classes\Queries\UniquePropertyValuesInCategoriesQuery;
+use OFFLINE\Mall\Classes\Traits\HashIds;
 
 class Property extends Model
 {
@@ -81,7 +80,7 @@ class Property extends Model
 
     public function afterSave()
     {
-        if ($this->pivot && !$this->pivot->use_for_variants) {
+        if ($this->pivot && ! $this->pivot->use_for_variants) {
             $categories = $this->property_groups->flatMap->getRelatedCategories();
 
             Product
@@ -102,17 +101,17 @@ class Property extends Model
 
         // Chunk the re-indexing since a lot of products and variants might be affected by this change.
         Product::published()
-            ->orderBy('id')
-            ->whereIn('id', $products)
-            ->with('variants')
-            ->chunk(25, function ($products) {
-                $data = [
-                    'properties' => [$this->id],
-                    'products'   => $products->pluck('id'),
-                    'variants'   => $products->flatMap->variants->pluck('id'),
-                ];
-                Queue::push(PropertyRemovalUpdate::class, $data);
-            });
+               ->orderBy('id')
+               ->whereIn('id', $products)
+               ->with('variants')
+               ->chunk(25, function ($products) {
+                   $data = [
+                       'properties' => [$this->id],
+                       'products'   => $products->pluck('id'),
+                       'variants'   => $products->flatMap->variants->pluck('id'),
+                   ];
+                   Queue::push(PropertyRemovalUpdate::class, $data);
+               });
     }
 
     public function getSortOrderAttribute()
@@ -136,7 +135,7 @@ class Property extends Model
         $values = $values->groupBy('property_id')->map(function ($values) {
             // if this property has options make sure to restore the original order
             $firstProp = $values->first()->property;
-            if (!$firstProp->options) {
+            if ( ! $firstProp->options) {
                 return $values;
             }
 
@@ -161,7 +160,7 @@ class Property extends Model
             'dropdown'   => trans('offline.mall::lang.custom_field_options.dropdown'),
             'checkbox'   => trans('offline.mall::lang.custom_field_options.checkbox'),
             'color'      => trans('offline.mall::lang.custom_field_options.color'),
-            //            'image'    => trans('offline.mall::lang.custom_field_options.image'),
+//            'image'    => trans('offline.mall::lang.custom_field_options.image'),
             'datetime'   => trans('offline.mall::lang.custom_field_options.datetime'),
             'date'       => trans('offline.mall::lang.custom_field_options.date'),
             'switch'     => trans('offline.mall::lang.custom_field_options.switch'),

--- a/models/Property.php
+++ b/models/Property.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Queue;
 use October\Rain\Database\Traits\Sluggable;
 use October\Rain\Database\Traits\SoftDelete;
 use October\Rain\Database\Traits\Validation;
+use OFFLINE\Mall\Models\UniquePropertyValue;
 use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
 use OFFLINE\Mall\Classes\Queries\UniquePropertyValuesInCategoriesQuery;
 use OFFLINE\Mall\Classes\Traits\HashIds;
@@ -121,17 +122,9 @@ class Property extends Model
 
     public static function getValuesForCategory($categories)
     {
-        $uniquePropertyValues = UniquePropertyValue::getForMultipleCategories($categories);
-        $raw = [];
-        foreach ($uniquePropertyValues as $uniquePropertyValue) {
-            $raw[] = [
-                'id' => $uniquePropertyValue->property_value_id,
-                'value' => $uniquePropertyValue->value,
-                'index_value' => $uniquePropertyValue->index_value,
-                'property_id' => $uniquePropertyValue->property_id,
-            ];
-        }
-        $values = PropertyValue::hydrate($raw)->load(['property.translations', 'translations']);
+        $values = UniquePropertyValue::hydratePropertyValuesForCategories($categories)
+            ->load(['property.translations', 'translations']);
+
         $values = $values->groupBy('property_id')->map(function ($values) {
             // if this property has options make sure to restore the original order
             $firstProp = $values->first()->property;

--- a/models/Property.php
+++ b/models/Property.php
@@ -55,6 +55,22 @@ class Property extends Model
         ],
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {
+            if ($relationName === 'property_groups') {
+                UniquePropertyValue::updateUsingProperty($this);
+            }
+        });
+        $this->bindEvent('model.relation.detach', function ($relationName, $attachedIdList) {
+            if ($relationName === 'property_groups') {
+                UniquePropertyValue::updateUsingProperty($this);
+            }
+        });
+    }
+
     public function afterSave()
     {
         if ($this->pivot && ! $this->pivot->use_for_variants) {
@@ -67,6 +83,8 @@ class Property extends Model
                 ->where('group_by_property_id', $this->id)
                 ->update(['group_by_property_id' => null]);
         }
+
+        UniquePropertyValue::updateUsingProperty($this);
     }
 
     public function afterDelete()

--- a/models/PropertyGroup.php
+++ b/models/PropertyGroup.php
@@ -98,12 +98,22 @@ class PropertyGroup extends Model
         $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {
             if ($relationName === 'properties') {
                 UniquePropertyValue::updateUsingPropertyGroup($this);
+            } elseif ($relationName === 'categories') {
+                foreach ($attachedIdList as $attachedId) {
+                    $category = Category::find($attachedId);
+                    UniquePropertyValue::updateUsingCategory($category);
+                }
             }
         });
 
-        $this->bindEvent('model.relation.detach', function ($relationName, $attachedIdList) {
+        $this->bindEvent('model.relation.detach', function ($relationName, $detachedIdList) {
             if ($relationName === 'properties') {
                 UniquePropertyValue::updateUsingPropertyGroup($this);
+            } elseif ($relationName === 'categories') {
+                foreach ($detachedIdList as $detachedId) {
+                    $category = Category::find($detachedId);
+                    UniquePropertyValue::updateUsingCategory($category);
+                }
             }
         });
     }

--- a/models/PropertyGroup.php
+++ b/models/PropertyGroup.php
@@ -94,6 +94,18 @@ class PropertyGroup extends Model
                        Queue::push(PropertyRemovalUpdate::class, $data);
                    });
         });
+
+        $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {
+            if ($relationName === 'properties') {
+                UniquePropertyValue::updateUsingPropertyGroup($this);
+            }
+        });
+
+        $this->bindEvent('model.relation.detach', function ($relationName, $attachedIdList) {
+            if ($relationName === 'properties') {
+                UniquePropertyValue::updateUsingPropertyGroup($this);
+            }
+        });
     }
 
     public function getDisplayNameAttribute()

--- a/models/PropertyGroup.php
+++ b/models/PropertyGroup.php
@@ -1,16 +1,14 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use Model;
 use Illuminate\Support\Facades\Queue;
-use October\Rain\Database\Traits\Sortable;
 use October\Rain\Database\Traits\Sluggable;
+use October\Rain\Database\Traits\Sortable;
 use October\Rain\Database\Traits\Validation;
-use OFFLINE\Mall\Classes\Traits\SortableRelation;
 use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
+use OFFLINE\Mall\Classes\Traits\SortableRelation;
 
 class PropertyGroup extends Model
 {
@@ -82,19 +80,19 @@ class PropertyGroup extends Model
             // Chunk the deletion and re-indexing since a lot of products and variants
             // might be affected by this change.
             Product::published()
-                ->orderBy('id')
-                ->whereHas('categories', function ($q) use ($categories) {
-                    $q->whereIn('category_id', $categories->pluck('id'));
-                })
-                ->with('variants')
-                ->chunk(25, function ($products) use ($properties) {
-                    $data = [
-                        'properties' => $properties,
-                        'products'   => $products->pluck('id'),
-                        'variants'   => $products->flatMap->variants->pluck('id'),
-                    ];
-                    Queue::push(PropertyRemovalUpdate::class, $data);
-                });
+                   ->orderBy('id')
+                   ->whereHas('categories', function ($q) use ($categories) {
+                       $q->whereIn('category_id', $categories->pluck('id'));
+                   })
+                   ->with('variants')
+                   ->chunk(25, function ($products) use ($properties) {
+                       $data = [
+                           'properties' => $properties,
+                           'products'   => $products->pluck('id'),
+                           'variants'   => $products->flatMap->variants->pluck('id'),
+                       ];
+                       Queue::push(PropertyRemovalUpdate::class, $data);
+                   });
         });
 
         $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {

--- a/models/PropertyGroup.php
+++ b/models/PropertyGroup.php
@@ -1,14 +1,16 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use Model;
 use Illuminate\Support\Facades\Queue;
-use October\Rain\Database\Traits\Sluggable;
 use October\Rain\Database\Traits\Sortable;
+use October\Rain\Database\Traits\Sluggable;
 use October\Rain\Database\Traits\Validation;
-use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
 use OFFLINE\Mall\Classes\Traits\SortableRelation;
+use OFFLINE\Mall\Classes\Jobs\PropertyRemovalUpdate;
 
 class PropertyGroup extends Model
 {
@@ -80,19 +82,19 @@ class PropertyGroup extends Model
             // Chunk the deletion and re-indexing since a lot of products and variants
             // might be affected by this change.
             Product::published()
-                   ->orderBy('id')
-                   ->whereHas('categories', function ($q) use ($categories) {
-                       $q->whereIn('category_id', $categories->pluck('id'));
-                   })
-                   ->with('variants')
-                   ->chunk(25, function ($products) use ($properties) {
-                       $data = [
-                           'properties' => $properties,
-                           'products'   => $products->pluck('id'),
-                           'variants'   => $products->flatMap->variants->pluck('id'),
-                       ];
-                       Queue::push(PropertyRemovalUpdate::class, $data);
-                   });
+                ->orderBy('id')
+                ->whereHas('categories', function ($q) use ($categories) {
+                    $q->whereIn('category_id', $categories->pluck('id'));
+                })
+                ->with('variants')
+                ->chunk(25, function ($products) use ($properties) {
+                    $data = [
+                        'properties' => $properties,
+                        'products'   => $products->pluck('id'),
+                        'variants'   => $products->flatMap->variants->pluck('id'),
+                    ];
+                    Queue::push(PropertyRemovalUpdate::class, $data);
+                });
         });
 
         $this->bindEvent('model.relation.attach', function ($relationName, $attachedIdList, $insertData) {

--- a/models/PropertyValue.php
+++ b/models/PropertyValue.php
@@ -1,11 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use Model;
-use October\Rain\Database\Traits\Validation;
-use OFFLINE\Mall\Classes\Traits\HashIds;
+use Queue;
 use System\Models\File;
+use OFFLINE\Mall\Classes\Traits\HashIds;
+use October\Rain\Database\Traits\Validation;
 
 class PropertyValue extends Model
 {
@@ -16,8 +19,7 @@ class PropertyValue extends Model
     public $translatable = [
         ['value', 'index' => true],
     ];
-    public $rules = [
-    ];
+    public $rules = [];
     public $fillable = [
         'value',
         'product_id',
@@ -159,7 +161,7 @@ class PropertyValue extends Model
     private function jsonDecodeValue($value = null)
     {
         $value = $value ?? $this->attributes['value'];
-        if ( ! $value) {
+        if (!$value) {
             return null;
         }
 
@@ -177,7 +179,7 @@ class PropertyValue extends Model
             $name = $value['name'] ?? false;
             $hex  = $value['hex'] ?? false;
             // If both keys are empty store this value as null.
-            if ( ! $name && ! $hex) {
+            if (!$name && !$hex) {
                 return null;
             }
         }

--- a/models/PropertyValue.php
+++ b/models/PropertyValue.php
@@ -1,14 +1,11 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace OFFLINE\Mall\Models;
 
 use Model;
-use Queue;
-use System\Models\File;
-use OFFLINE\Mall\Classes\Traits\HashIds;
 use October\Rain\Database\Traits\Validation;
+use OFFLINE\Mall\Classes\Traits\HashIds;
+use System\Models\File;
 
 class PropertyValue extends Model
 {
@@ -19,7 +16,8 @@ class PropertyValue extends Model
     public $translatable = [
         ['value', 'index' => true],
     ];
-    public $rules = [];
+    public $rules = [
+    ];
     public $fillable = [
         'value',
         'product_id',
@@ -161,7 +159,7 @@ class PropertyValue extends Model
     private function jsonDecodeValue($value = null)
     {
         $value = $value ?? $this->attributes['value'];
-        if (!$value) {
+        if ( ! $value) {
             return null;
         }
 
@@ -179,7 +177,7 @@ class PropertyValue extends Model
             $name = $value['name'] ?? false;
             $hex  = $value['hex'] ?? false;
             // If both keys are empty store this value as null.
-            if (!$name && !$hex) {
+            if ( ! $name && ! $hex) {
                 return null;
             }
         }

--- a/models/PropertyValue.php
+++ b/models/PropertyValue.php
@@ -62,6 +62,11 @@ class PropertyValue extends Model
         $this->index_value = str_slug($value);
     }
 
+    public function afterSave(): void
+    {
+        UniquePropertyValue::updateUsingPropertyValue($this);
+    }
+
     public function setValueAttribute($value)
     {
         $this->attributes['value'] = $this->handleArrayValue($value);

--- a/models/UniquePropertyValue.php
+++ b/models/UniquePropertyValue.php
@@ -50,6 +50,12 @@ class UniquePropertyValue extends Model
         'category'  => [Category::class],
     ];
 
+    /**
+     * Get unique properties for provided categories (no duplicates throughout all of them)
+     *
+     * @param Collection $categories
+     * @return Collection
+     */
     public static function getForMultipleCategories(Collection $categories): Collection
     {
         $ids = self::selectRaw('MIN(property_value_id), value, index_value, property_id')
@@ -60,6 +66,7 @@ class UniquePropertyValue extends Model
 
         return self::whereIn('id', $ids)->get();
     }
+
     /**
      * Reset unique properties for provided category
      *
@@ -104,9 +111,9 @@ class UniquePropertyValue extends Model
     }
 
     /**
-     * Update unique property values using product
+     * Update unique property values using category
      *
-     * @param Product $product
+     * @param Category $category
      * @return void
      */
     public static function updateUsingCategory(Category $category): void
@@ -116,7 +123,6 @@ class UniquePropertyValue extends Model
 
     /**
      * Update unique property values using product
-     * It's looking for all categories that the product is in and updates it
      *
      * @param Product $product
      * @return void
@@ -129,6 +135,12 @@ class UniquePropertyValue extends Model
         }
     }
 
+    /**
+     * Update unique property values using property group
+     *
+     * @param PropertyGroup $propertyGroup
+     * @return void
+     */
     public static function updateUsingPropertyGroup(PropertyGroup $propertyGroup): void
     {
         $propertyGroup->loadMissing(['categories']);
@@ -137,6 +149,12 @@ class UniquePropertyValue extends Model
         }
     }
 
+    /**
+     * Update unique property values using property
+     *
+     * @param Property $property
+     * @return void
+     */
     public static function updateUsingProperty(Property $property): void
     {
         $property->loadMissing(['property_groups.categories']);
@@ -145,12 +163,24 @@ class UniquePropertyValue extends Model
         }
     }
 
+    /**
+     * Update unique property values using property value
+     *
+     * @param PropertyValue $propertyValue
+     * @return void
+     */
     public static function updateUsingPropertyValue(PropertyValue $propertyValue): void
     {
         $propertyValue->loadMissing(['product.categories']);
         self::updateUsingProduct($propertyValue->product);
     }
 
+    /**
+     * Get unique properties for category query
+     *
+     * @param Category $category
+     * @return Builder
+     */
     public static function getRawQueryForCategory(Category $category): Builder
     {
         return DB

--- a/models/UniquePropertyValue.php
+++ b/models/UniquePropertyValue.php
@@ -172,7 +172,15 @@ class UniquePropertyValue extends Model
     public static function updateUsingPropertyValue(PropertyValue $propertyValue): void
     {
         $propertyValue->loadMissing(['product.categories']);
-        self::updateUsingProduct($propertyValue->product);
+        $product = $propertyValue->product;
+
+        if (!$product) {
+            $product = Product::with(['categories'])->where('id', $propertyValue->product_id)->first();
+        }
+
+        if ($product) {
+            self::updateUsingProduct($product);
+        }
     }
 
     /**

--- a/models/UniquePropertyValue.php
+++ b/models/UniquePropertyValue.php
@@ -51,20 +51,20 @@ class UniquePropertyValue extends Model
     ];
 
     /**
-     * Get unique properties for provided categories (no duplicates throughout all of them)
+     * Get property values for provided categories without duplicates
      *
      * @param Collection $categories
      * @return Collection
      */
-    public static function getForMultipleCategories(Collection $categories): Collection
+    public static function hydratePropertyValuesForCategories(Collection $categories): Collection
     {
-        $ids = self::selectRaw('MIN(property_value_id), value, index_value, property_id')
+        $raw = self::selectRaw('MIN(property_value_id) as id, value, index_value, property_id')
             ->whereIn('category_id', $categories->pluck('id'))
             ->groupBy('value', 'index_value', 'property_id')
-            ->get('id')
-            ->pluck('id');
+            ->get()
+            ->toArray();
 
-        return self::whereIn('id', $ids)->get();
+        return PropertyValue::hydrate($raw);
     }
 
     /**

--- a/models/UniquePropertyValue.php
+++ b/models/UniquePropertyValue.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OFFLINE\Mall\Models;
+
+use Model;
+use OFFLINE\Mall\Models\PropertyGroup;
+use OFFLINE\Mall\Models\PropertyValue;
+use October\Rain\Database\Traits\Validation;
+
+class UniquePropertyValue extends Model
+{
+    use Validation;
+
+    /**
+     * @var string table name
+     */
+    public $table = 'offline_mall_unique_property_values';
+
+    /**
+     * @var array rules for validation
+     */
+    public $rules = [
+        'property_value_id' => 'required|exists:offline_mall_property_values,id',
+        'property_id' => 'required|exists:offline_mall_properties,id',
+        'category_id' => 'required|exists:offline_mall_categories,id',
+        'value' => 'required',
+        'index_value' => 'required',
+    ];
+
+    public $timestamps = false;
+
+    public $fillable = [
+        'property_value_id',
+        'property_id',
+        'value',
+        'index_value',
+        'category_id',
+    ];
+
+    public $belongsTo = [
+        'property' => [Property::class, 'deleted' => true],
+        'property_value' => [PropertyValue::class, 'deleted' => true],
+        'category'  => [Category::class],
+    ];
+
+    /**
+     * Update unique property values using category
+     * It's looking for all products in the category and updating uniques just for them
+     *
+     * @param Category $category
+     * @return void
+     */
+    public static function updateUsingCategory(Category $category): void
+    {
+        $products = Product::whereHas('categories', function ($q) use ($category) {
+            $q->where($category->getTable() . '.id', $category->id);
+        })->with([
+            'property_values',
+            'variants.property_values',
+        ])->get();
+
+        $uniqueIdsToLeave = [];
+        foreach ($products as $product) {
+            $propertyValues = $product->property_values ?? [];
+            foreach ($propertyValues as $propertyValue) {
+                $uniquePropertyValue = self::whereOrCreate([
+                    'property_id' => $propertyValue->property_id,
+                    'property_value_id' => $propertyValue->id,
+                    'category_id' => $category->id,
+                    'value' => $propertyValue->value,
+                    'index_value' => $propertyValue->index_value,
+                ]);
+
+                $uniqueIdsToLeave[] = $uniquePropertyValue->id;
+            }
+
+            $variants = $product->variants ?? [];
+            foreach ($variants as $variant) {
+                $propertyValues = $variant->property_values ?? [];
+                foreach ($propertyValues as $propertyValue) {
+                    $uniquePropertyValue = self::whereOrCreate([
+                        'property_id' => $propertyValue->property_id,
+                        'property_value_id' => $propertyValue->id,
+                        'category_id' => $category->id,
+                        'value' => $propertyValue->value,
+                        'index_value' => $propertyValue->index_value,
+                    ]);
+
+                    $uniqueIdsToLeave[] = $uniquePropertyValue->id;
+                }
+            }
+        }
+
+        // Cleanup all properties that were already deleted from the category
+        $productPropertyValuesIds = PropertyValue::whereIn('product_id', $products->pluck('id'))
+            ->get('id')
+            ->pluck('id');
+
+        UniquePropertyValue::whereIn('property_value_id', $productPropertyValuesIds)
+            ->whereNotIn('id', $uniqueIdsToLeave)
+            ->delete();
+    }
+
+    /**
+     * Update unique property values using product
+     * It's looking for all categories that the product is in and updates it
+     *
+     * @param Product $product
+     * @return void
+     */
+    public static function updateUsingProduct(Product $product): void
+    {
+        $product->loadMissing([
+            'categories',
+            'property_values',
+            'variants.property_values'
+        ]);
+
+        $uniqueIdsToLeave = [];
+        foreach ($product->categories as $category) {
+            $propertyValues = $product->property_values ?? [];
+            foreach ($propertyValues as $propertyValue) {
+                $uniquePropertyValue = self::whereOrCreate([
+                    'property_id' => $propertyValue->property_id,
+                    'property_value_id' => $propertyValue->id,
+                    'category_id' => $category->id,
+                    'value' => $propertyValue->value,
+                    'index_value' => $propertyValue->index_value,
+                ]);
+
+                $uniqueIdsToLeave[] = $uniquePropertyValue->id;
+
+                $variants = $product->variants ?? [];
+                foreach ($variants as $variant) {
+                    $propertyValues = $variant->property_values ?? [];
+                    foreach ($propertyValues as $propertyValue) {
+                        $uniquePropertyValue = self::whereOrCreate([
+                            'property_id' => $propertyValue->property_id,
+                            'property_value_id' => $propertyValue->id,
+                            'category_id' => $category->id,
+                            'value' => $propertyValue->value,
+                            'index_value' => $propertyValue->index_value,
+                        ]);
+
+                        $uniqueIdsToLeave[] = $uniquePropertyValue->id;
+                    }
+                }
+            }
+        }
+
+        // Cleanup all properties that the product lost on the way
+        $productPropertyValuesIds = PropertyValue::where('product_id', $product->id)
+            ->get('id')
+            ->pluck('id');
+
+        UniquePropertyValue::whereIn('property_value_id', $productPropertyValuesIds)
+            ->whereNotIn('id', $uniqueIdsToLeave)
+            ->delete();
+    }
+
+    public static function updateUsingPropertyGroup(PropertyGroup $propertyGroup): void
+    {
+        $propertyGroup->loadMissing(['categories']);
+        foreach ($propertyGroup->categories as $category) {
+            self::updateUsingCategory($category);
+        }
+    }
+
+    public static function updateUsingProperty(Property $property): void
+    {
+        foreach ($property->property_groups as $propertyGroup) {
+            self::updateUsingPropertyGroup($propertyGroup);
+        }
+    }
+
+    public static function updateUsingPropertyValue(PropertyValue $propertyValue): void
+    {
+        self::updateUsingProduct($propertyValue->product);
+    }
+
+    /**
+     * Helper method, similar to firstOrCreate, but
+     * we're not using property_value_id when looking for model but we're storing it
+     *
+     * @param array $data
+     * @return self
+     */
+    public static function whereOrCreate(array $data): self
+    {
+        $uniquePropertyValue = UniquePropertyValue::where('property_id', $data['property_id'])
+            ->where('category_id', $data['category_id'])
+            ->where('value', $data['value'])
+            ->where('index_value', $data['index_value'])
+            ->first();
+
+        if (!$uniquePropertyValue) {
+            $uniquePropertyValue = new UniquePropertyValue();
+            $uniquePropertyValue->property_id = $data['property_id'];
+            $uniquePropertyValue->property_value_id = $data['property_value_id'];
+            $uniquePropertyValue->category_id = $data['category_id'];
+            $uniquePropertyValue->value = $data['value'];
+            $uniquePropertyValue->index_value = $data['index_value'];
+            $uniquePropertyValue->save();
+        }
+
+        return $uniquePropertyValue;
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,7 @@
         <env name="APP_ENV" value="testing" />
         <env name="CACHE_DRIVER" value="array" />
         <env name="SESSION_DRIVER" value="array" />
+        <env name="QUEUE_CONNECTION" value="sync" />
         <env name="ACTIVE_THEME" value="mall" />
         <env name="CONVERT_LINE_ENDINGS" value="true" />
         <env name="CMS_ROUTE_CACHE" value="true" />

--- a/tests/queries/UniquePropertyValuesInCategoriesQueryTest.php
+++ b/tests/queries/UniquePropertyValuesInCategoriesQueryTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OFFLINE\Mall\Tests\Queries;
+
+use OFFLINE\Mall\Models\Product;
+use OFFLINE\Mall\Models\Category;
+use OFFLINE\Mall\Models\Property;
+use OFFLINE\Mall\Models\PropertyGroup;
+use OFFLINE\Mall\Models\PropertyValue;
+use OFFLINE\Mall\Tests\PluginTestCase;
+use OFFLINE\Mall\Classes\Queries\UniquePropertyValuesInCategoriesQuery;
+
+class UniquePropertyValuesInCategoriesQueryTest extends PluginTestCase
+{
+    public function test_query_returns_valid_properties(): void
+    {
+        $category1 = new Category();
+        $category1->name = 'Category 1';
+        $category1->slug = 'category-1';
+        $category1->save();
+
+        $propertyGroup1 = new PropertyGroup();
+        $propertyGroup1->name = 'Property group 1';
+        $propertyGroup1->slug = 'property-group-1';
+        $propertyGroup1->save();
+
+        $property1 = new Property();
+        $property1->name = 'Property 1';
+        $property1->slug = 'property-1';
+        $property1->type = 'dropdown';
+        $property1->save();
+
+        $property2 = new Property();
+        $property2->name = 'Property 2';
+        $property2->slug = 'property-2';
+        $property2->type = 'dropdown';
+        $property2->save();
+
+        $propertyGroup1->categories()->add($category1);
+        $propertyGroup1->properties()->add($property1);
+        $propertyGroup1->properties()->add($property2);
+
+        $category2 = new Category();
+        $category2->name = "Category 2";
+        $category2->slug = "category-2";
+        $category2->save();
+
+        $propertyGroup2 = new PropertyGroup();
+        $propertyGroup2->name = 'Property group 2';
+        $propertyGroup2->slug = 'property-group-2';
+        $propertyGroup2->save();
+
+        $property3 = new Property();
+        $property3->name = 'Property 3';
+        $property3->slug = 'property-3';
+        $property3->type = 'dropdown';
+        $property3->save();
+
+        $property4 = new Property();
+        $property4->name = 'Property 4';
+        $property4->slug = 'property-4';
+        $property4->type = 'dropdown';
+        $property4->save();
+
+        $propertyGroup2->categories()->add($category2);
+        $propertyGroup2->properties()->add($property1);
+        $propertyGroup2->properties()->add($property3);
+        $propertyGroup2->properties()->add($property4);
+
+        $products = Product::all();
+        $products[0]->categories()->add($category1);
+        $products[1]->categories()->add($category2);
+
+        $propertyValue1 = new PropertyValue();
+        $propertyValue1->product_id = $products[0]->id;
+        $propertyValue1->property_id = $property1->id;
+        $propertyValue1->value = 'Property 1 value for product 1';
+        $propertyValue1->save();
+
+        $propertyValue2 = new PropertyValue();
+        $propertyValue2->product_id = $products[0]->id;
+        $propertyValue2->property_id = $property2->id;
+        $propertyValue2->value = 'Property 2 value for product 1';
+        $propertyValue2->save();
+
+        $propertyValue3 = new PropertyValue();
+        $propertyValue3->product_id = $products[0]->id;
+        $propertyValue3->property_id = $property2->id;
+        $propertyValue3->value = 'Property 2 value for product 1';
+        $propertyValue3->save();
+
+        $propertyValue4 = new PropertyValue();
+        $propertyValue4->product_id = $products[1]->id;
+        $propertyValue4->property_id = $property3->id;
+        $propertyValue4->value = 'Property 3 value for product 2';
+        $propertyValue4->save();
+
+        $propertyValue5 = new PropertyValue();
+        $propertyValue5->product_id = $products[1]->id;
+        $propertyValue5->property_id = $property4->id;
+        $propertyValue5->value = 'Property 4 value for product 2';
+        $propertyValue5->save();
+
+        // There are two filled properties for category-1
+        $categories = Category::where('slug', 'category-1')->get();
+        $records = (new UniquePropertyValuesInCategoriesQuery($categories))->query()->get();
+        $this->assertEquals(2, $records->count());
+        $this->assertEquals($records[0]->value, 'Property 1 value for product 1');
+        $this->assertEquals($records[1]->value, 'Property 2 value for product 1');
+
+        // There are two filled properties for category-2 (and three attached)
+        $categories = Category::where('slug', 'category-2')->get();
+        $records = (new UniquePropertyValuesInCategoriesQuery($categories))->query()->get();
+        $this->assertEquals(2, $records->count());
+        $this->assertEquals($records[0]->value, 'Property 3 value for product 2');
+        $this->assertEquals($records[1]->value, 'Property 4 value for product 2');
+
+        // There are 4 filled properties for both categories (and five attached to both)
+        $categories = Category::where('slug', 'like', 'category%')->get();
+        $records = (new UniquePropertyValuesInCategoriesQuery($categories))->query()->get();
+        $this->assertEquals(4, $records->count());
+        $this->assertEquals($records[0]->value, 'Property 1 value for product 1');
+        $this->assertEquals($records[1]->value, 'Property 2 value for product 1');
+        $this->assertEquals($records[2]->value, 'Property 3 value for product 2');
+        $this->assertEquals($records[3]->value, 'Property 4 value for product 2');
+    }
+}

--- a/tests/queries/UniquePropertyValuesInCategoriesQueryTest.php
+++ b/tests/queries/UniquePropertyValuesInCategoriesQueryTest.php
@@ -118,7 +118,7 @@ class UniquePropertyValuesInCategoriesQueryTest extends PluginTestCase
         $this->assertEquals($records[0]->value, 'Property 1 value for product 1');
         $this->assertEquals($records[1]->value, 'Property 2 value for product 1');
 
-        $records = UniquePropertyValue::getForMultipleCategories($categories);
+        $records = UniquePropertyValue::hydratePropertyValuesForCategories($categories);
         $this->assertEquals(2, $records->count());
         $this->assertEquals($records[0]->value, 'Property 1 value for product 1');
         $this->assertEquals($records[1]->value, 'Property 2 value for product 1');
@@ -131,12 +131,11 @@ class UniquePropertyValuesInCategoriesQueryTest extends PluginTestCase
         $this->assertEquals($records[1]->value, 'Property 3 value for product 2');
         $this->assertEquals($records[2]->value, 'Property 4 value for product 2');
 
-        $records = UniquePropertyValue::getForMultipleCategories($categories);
+        $records = UniquePropertyValue::hydratePropertyValuesForCategories($categories);
         $this->assertEquals(3, $records->count());
-        // Only order differs, it doesn't matter, does it?
-        $this->assertEquals($records[0]->value, 'Property 3 value for product 2');
-        $this->assertEquals($records[1]->value, 'Property 4 value for product 2');
-        $this->assertEquals($records[2]->value, 'Property 1 value for product 1');
+        $this->assertEquals($records[0]->value, 'Property 1 value for product 1');
+        $this->assertEquals($records[1]->value, 'Property 3 value for product 2');
+        $this->assertEquals($records[2]->value, 'Property 4 value for product 2');
 
         // There are 4 unique properties' values for both categories
         // One is duplicated and the second has the same value for a different product
@@ -148,7 +147,7 @@ class UniquePropertyValuesInCategoriesQueryTest extends PluginTestCase
         $this->assertEquals($records[2]->value, 'Property 3 value for product 2');
         $this->assertEquals($records[3]->value, 'Property 4 value for product 2');
 
-        $records = UniquePropertyValue::getForMultipleCategories($categories);
+        $records = UniquePropertyValue::hydratePropertyValuesForCategories($categories);
         $this->assertEquals(4, $records->count());
         $this->assertEquals($records[0]->value, 'Property 1 value for product 1');
         $this->assertEquals($records[1]->value, 'Property 2 value for product 1');

--- a/updates/031_01-create_unique_property_values_table.php
+++ b/updates/031_01-create_unique_property_values_table.php
@@ -35,24 +35,16 @@ class CreateUniquePropertyValuesTable_031_01 extends Migration
             $table->text('index_value')->nullable();
 
             if (!app()->runningUnitTests()) {
-                // We're using all four columns in where clauses, thus index on all of them
+                // We're using all four columns in selects, thus index on all of them
                 $table->index(['property_id', 'category_id', 'value', 'index_value'], 'idx_property_values_categories');
             }
         });
 
-        foreach (Category::all() as $category) {
-            $records = $this->oldQuery($category)->get();
-
-            foreach ($records as $record) {
-                $uniquePropertyValue = new UniquePropertyValue();
-                $uniquePropertyValue->category_id = $category->id;
-                $uniquePropertyValue->property_value_id = $record->id;
-                $uniquePropertyValue->property_id = $record->property_id;
-                $uniquePropertyValue->value = $record->value;
-                $uniquePropertyValue->index_value = $record->index_value;
-                $uniquePropertyValue->save();
+        DB::transaction(function () {
+            foreach (Category::all() as $category) {
+                UniquePropertyValue::resetForCategory($category);
             }
-        }
+        });
     }
 
     /**
@@ -67,48 +59,5 @@ class CreateUniquePropertyValuesTable_031_01 extends Migration
 
     public function oldQuery($category)
     {
-        return DB
-            ::table('offline_mall_products')
-            ->selectRaw(
-                '
-                MIN(offline_mall_property_values.id) AS id,
-                offline_mall_property_values.value,
-                offline_mall_property_values.index_value,
-                offline_mall_property_values.property_id'
-            )
-            ->where(function ($q) {
-                $q->where(function ($q) {
-                    $q->where('offline_mall_products.published', true)
-                        ->whereNull('offline_mall_product_variants.id');
-                })->orWhere('offline_mall_product_variants.published', true);
-            })
-            ->where('offline_mall_category_product.category_id', $category->id)
-            ->whereNull('offline_mall_product_variants.deleted_at')
-            ->whereNull('offline_mall_products.deleted_at')
-            ->where('offline_mall_property_values.value', '<>', '')
-            ->whereNotNull('offline_mall_property_values.value')
-            ->groupBy(
-                'offline_mall_property_values.value',
-                'offline_mall_property_values.index_value',
-                'offline_mall_property_values.property_id'
-            )
-            ->leftJoin(
-                'offline_mall_product_variants',
-                'offline_mall_products.id',
-                '=',
-                'offline_mall_product_variants.product_id'
-            )
-            ->leftJoin(
-                'offline_mall_category_product',
-                'offline_mall_products.id',
-                '=',
-                'offline_mall_category_product.product_id'
-            )
-            ->join(
-                'offline_mall_property_values',
-                'offline_mall_products.id',
-                '=',
-                'offline_mall_property_values.product_id'
-            );
     }
 };

--- a/updates/031_01-create_unique_property_values_table.php
+++ b/updates/031_01-create_unique_property_values_table.php
@@ -35,8 +35,7 @@ class CreateUniquePropertyValuesTable_031_01 extends Migration
             $table->text('index_value')->nullable();
 
             if (!app()->runningUnitTests()) {
-                // We're using all four columns in selects, thus index on all of them
-                $table->index(['property_id', 'category_id', 'value', 'index_value'], 'idx_property_values_categories');
+                $table->index(['property_id', 'category_id'], 'idx_property_values_categories');
             }
         });
 

--- a/updates/031_01-create_unique_property_values_table.php
+++ b/updates/031_01-create_unique_property_values_table.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OFFLINE\Mall\Updates;
+
+use DB;
+use Schema;
+use OFFLINE\Mall\Models\Category;
+use October\Rain\Database\Schema\Blueprint;
+use October\Rain\Database\Updates\Migration;
+use OFFLINE\Mall\Models\UniquePropertyValue;
+
+/**
+ * CreateUniquePropertyValuesTable Migration
+ *
+ * @link https://docs.octobercms.com/3.x/extend/database/structure.html
+ */
+class CreateUniquePropertyValuesTable_031_01 extends Migration
+{
+    /**
+     * Install Migration
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('offline_mall_unique_property_values', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id')->unsigned();
+            $table->integer('property_value_id')->unsigned();
+            $table->integer('property_id')->unsigned();
+            $table->integer('category_id')->unsigned();
+            $table->text('value')->nullable();
+            $table->text('index_value')->nullable();
+
+            if (!app()->runningUnitTests()) {
+                // We're using all four columns in where clauses, thus index on all of them
+                $table->index(['property_id', 'category_id', 'value', 'index_value'], 'idx_property_values_categories');
+            }
+        });
+
+        foreach (Category::all() as $category) {
+            $records = $this->oldQuery($category)->get();
+
+            foreach ($records as $record) {
+                $uniquePropertyValue = new UniquePropertyValue();
+                $uniquePropertyValue->category_id = $category->id;
+                $uniquePropertyValue->property_value_id = $record->id;
+                $uniquePropertyValue->property_id = $record->property_id;
+                $uniquePropertyValue->value = $record->value;
+                $uniquePropertyValue->index_value = $record->index_value;
+                $uniquePropertyValue->save();
+            }
+        }
+    }
+
+    /**
+     * Uninstall Migration
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('offline_mall_unique_property_values');
+    }
+
+    public function oldQuery($category)
+    {
+        return DB
+            ::table('offline_mall_products')
+            ->selectRaw(
+                '
+                MIN(offline_mall_property_values.id) AS id,
+                offline_mall_property_values.value,
+                offline_mall_property_values.index_value,
+                offline_mall_property_values.property_id'
+            )
+            ->where(function ($q) {
+                $q->where(function ($q) {
+                    $q->where('offline_mall_products.published', true)
+                        ->whereNull('offline_mall_product_variants.id');
+                })->orWhere('offline_mall_product_variants.published', true);
+            })
+            ->where('offline_mall_category_product.category_id', $category->id)
+            ->whereNull('offline_mall_product_variants.deleted_at')
+            ->whereNull('offline_mall_products.deleted_at')
+            ->where('offline_mall_property_values.value', '<>', '')
+            ->whereNotNull('offline_mall_property_values.value')
+            ->groupBy(
+                'offline_mall_property_values.value',
+                'offline_mall_property_values.index_value',
+                'offline_mall_property_values.property_id'
+            )
+            ->leftJoin(
+                'offline_mall_product_variants',
+                'offline_mall_products.id',
+                '=',
+                'offline_mall_product_variants.product_id'
+            )
+            ->leftJoin(
+                'offline_mall_category_product',
+                'offline_mall_products.id',
+                '=',
+                'offline_mall_category_product.product_id'
+            )
+            ->join(
+                'offline_mall_property_values',
+                'offline_mall_products.id',
+                '=',
+                'offline_mall_property_values.product_id'
+            );
+    }
+};

--- a/updates/031_01-create_unique_property_values_table.php
+++ b/updates/031_01-create_unique_property_values_table.php
@@ -56,8 +56,4 @@ class CreateUniquePropertyValuesTable_031_01 extends Migration
     {
         Schema::dropIfExists('offline_mall_unique_property_values');
     }
-
-    public function oldQuery($category)
-    {
-    }
 };

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -579,3 +579,6 @@ v3.3.1:
     - 'Minor Bugfixes'
     - 'Fixed strict variables issue on oldPrice() attribute, thanks to @dathwa (#1118).'
     - 'Fixed stripe purchase issue, thanks to @dathwa (#1145).'
+v3.4.0:
+    - 'Add Unique Property Values'
+    - 031_01-create_unique_property_values_table.php


### PR DESCRIPTION
Hi @tobias-kuendig,

In regards to https://github.com/OFFLINE-GmbH/oc-mall-plugin/issues/1149 I'm filling this PR. It basically moves the "big" query to queue when updating particular models, but makes fetching really quick. In my case it optimised loading the page from ~3 minutes to 8 seconds with the same functionality (I know it's still long, but let's ignore it for now ;) ).

I wrote a test that checks if the new approach returns the same set of values. Underneath, I haven't changed the original query, I use it to fill correct records to the db.

It's a first version so I'm open to any suggestions.

Cheers,

Tomasz Strojny