### PR TITLE
Prevent from adding too many queue jobs for UniquePropertyValue

### DIFF
--- a/models/UniquePropertyValue.php
+++ b/models/UniquePropertyValue.php
@@ -140,7 +140,7 @@ class UniquePropertyValue extends Model
     {
         $product->loadMissing(['categories']);
         foreach ($product->categories as $category) {
-            Queue::push(UpdateUniquePropertyForCategory::class, ['id' => $category->id]);
+            self::updateUsingCategory($category);
         }
     }
 
@@ -154,7 +154,7 @@ class UniquePropertyValue extends Model
     {
         $propertyGroup->loadMissing(['categories']);
         foreach ($propertyGroup->categories as $category) {
-            Queue::push(UpdateUniquePropertyForCategory::class, ['id' => $category->id]);
+            self::updateUsingCategory($category);
         }
     }
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -586,3 +586,5 @@ v3.3.2:
 v3.4.0:
     - 'Optimized unique property queries (thanks to @tomaszstrojny)'
     - 031_01-create_unique_property_values_table.php
+v3.4.1:
+    - 'Prevent from adding too many queue jobs for UniquePropertyValue'


### PR DESCRIPTION
Hi @tobias-kuendig,

As mentioned, one more thing re unique properties.

It turned out that we were adding too many queue jobs. The fix is just preventing it by running single command.

Not a big deal.

Thanks for a great plugin mate!

