### PR TITLE
fixed "The surname field is required" Validation bug

### DIFF
--- a/updates/seeders/tables/CustomerTableSeeder.php
+++ b/updates/seeders/tables/CustomerTableSeeder.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace OFFLINE\Mall\Updates\Seeders\Tables;
 
@@ -60,8 +62,8 @@ class CustomerTableSeeder extends Seeder
         ], [
             'password'                  => '12345678',
             'password_confirmation'     => '12345678',
-            'first_name'                => $firstname,
-            'last_name'                 => $lastname,
+            'name'                      => $firstname,
+            'surname'                   => $lastname,
         ]);
         $user->offline_mall_customer_group_id = $customerGroupId;
         $user->save();


### PR DESCRIPTION
Hi!

using the newest github and october registry version of the mall plugin while seeding with example data using:

```bash
php artisan mall:seed --verbose -d 
```

 i encountered an:

```bash
The surname field is required.
/home/prfl/Projects/depcore/oc-instance/vendor/october/rain/src/Database/Traits/Validation.php
```

the fix was to edit the CustomerTableSeeder.php where the parameters were deprecated.
changing first_name to name and last_name to surname fixed the error!

Have a great day and keep up with the great work of bringing ecommerce to october <3