### PR TITLE
MySQL raw expressions have __toString removed for Laravel 10+

### DIFF
--- a/classes/index/mysql/MySQL.php
+++ b/classes/index/mysql/MySQL.php
@@ -5,6 +5,7 @@ namespace OFFLINE\Mall\Classes\Index\MySQL;
 use Cache;
 use DB;
 use Event;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 use October\Rain\Database\Schema\Blueprint;
 use OFFLINE\Mall\Classes\CategoryFilter\Filter;
@@ -19,7 +20,6 @@ use OFFLINE\Mall\Classes\Index\IndexResult;
 use OFFLINE\Mall\Models\Currency;
 use Schema;
 use Throwable;
-use Illuminate\Foundation\Application;
 
 class MySQL implements Index
 {

--- a/classes/index/mysql/MySQL.php
+++ b/classes/index/mysql/MySQL.php
@@ -101,7 +101,7 @@ class MySQL implements Index
                 );
                 $table->index(['index', 'published'], 'idx_published_index');
             });
-            
+
             // Allow the index table to be extended with custom columns
             Event::fire('mall.index.mysql.extendTable', [$table]);
         } catch (Throwable $e) {
@@ -166,14 +166,14 @@ class MySQL implements Index
             'customer_group_prices' => $data['customer_group_prices'] ?? [],
             'created_at'            => $data['created_at'] ?? now(),
         ];
-        
+
         // Allow the index data to be extended with custom information
         $customIndexData = Event::fire('mall.index.extendData', [$data]);
 
         if(!empty($customIndexData) && is_array($customIndexData[0])) {
             $indexData = array_merge($indexData, $customIndexData[0]);
         }
-        
+
         $this->db()->updateOrCreate([
             'index'      => $index,
             'product_id' => $productId,
@@ -287,10 +287,12 @@ class MySQL implements Index
             $nested = implode('.', $parts);
 
             // Apply the right cast for this value. This makes sure, that prices are sorted as floats, not as strings.
+            $expression = DB::raw($field)->getValue(DB::connection()->getQueryGrammar());
+
             if (isset($this->columnCasts[$field])) {
-                $orderBy = sprintf('CAST(JSON_EXTRACT(%s, ?) as %s) %s', DB::raw($field), $this->columnCasts[$field], $order->direction());
+                $orderBy = sprintf('CAST(JSON_EXTRACT(%s, ?) as %s) %s', $expression, $this->columnCasts[$field], $order->direction());
             } else {
-                $orderBy = sprintf('JSON_EXTRACT(%s, ?) %s', DB::raw($field), $order->direction());
+                $orderBy = sprintf('JSON_EXTRACT(%s, ?) %s', $expression, $order->direction());
             }
 
             $db->orderByRaw($orderBy, ['$.' . '"' . $nested . '"']);

--- a/classes/index/mysql/MySQL.php
+++ b/classes/index/mysql/MySQL.php
@@ -2,24 +2,24 @@
 
 namespace OFFLINE\Mall\Classes\Index\MySQL;
 
-use DB;
 use Cache;
+use DB;
 use Event;
-use Schema;
-use Throwable;
-use OFFLINE\Mall\Models\Currency;
 use Illuminate\Support\Collection;
+use October\Rain\Database\Schema\Blueprint;
+use OFFLINE\Mall\Classes\CategoryFilter\Filter;
+use OFFLINE\Mall\Classes\CategoryFilter\RangeFilter;
+use OFFLINE\Mall\Classes\CategoryFilter\SetFilter;
+use OFFLINE\Mall\Classes\CategoryFilter\SortOrder\Random;
+use OFFLINE\Mall\Classes\CategoryFilter\SortOrder\SortOrder;
 use OFFLINE\Mall\Classes\Index\Entry;
 use OFFLINE\Mall\Classes\Index\Index;
-use Illuminate\Foundation\Application;
-use October\Rain\Database\Schema\Blueprint;
-use OFFLINE\Mall\Classes\Index\IndexResult;
-use OFFLINE\Mall\Classes\CategoryFilter\Filter;
-use OFFLINE\Mall\Classes\CategoryFilter\SetFilter;
-use OFFLINE\Mall\Classes\CategoryFilter\RangeFilter;
-use OFFLINE\Mall\Classes\CategoryFilter\SortOrder\Random;
 use OFFLINE\Mall\Classes\Index\IndexNotSupportedException;
-use OFFLINE\Mall\Classes\CategoryFilter\SortOrder\SortOrder;
+use OFFLINE\Mall\Classes\Index\IndexResult;
+use OFFLINE\Mall\Models\Currency;
+use Schema;
+use Throwable;
+use Illuminate\Foundation\Application;
 
 class MySQL implements Index
 {

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -611,3 +611,5 @@ v3.5.3:
     - 'Fixed guest signup'
 v3.5.4:
     - 'Refactgored built-in validation rule'
+v3.5.5:
+    - 'Fix raw query for Laravel 10+'


### PR DESCRIPTION
Hi @tobias-kuendig !

The PR is basically self explanatory but yea, Laravel 10 changed the way expressions are converted to strings. See the docs here: https://laravel.com/docs/10.x/upgrade#database-expressions

Here's the commit in Laravel's code (yea I looked for a better way ;) ): 

https://github.com/illuminate/database/commit/34a71007a8f3a5f617c4e608d73ec3a1aced9272#diff-8466082f196fa1a3b3ad9815d14d79e5139ae900d2edf7c74ea922a67b281a45R34

To keep backwards compatibility I decided to check Laravel's version and apply the fix only for the versions above 10. Not sure it's the best way to go so let me know if you'd see it solved better.

Thanks,

Tomasz