### PR TITLE
Fix products filter category collection type

### DIFF
--- a/components/ProductsFilter.php
+++ b/components/ProductsFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OFFLINE\Mall\Components;
 
 use DB;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
 use OFFLINE\Mall\Classes\CategoryFilter\Filter;
@@ -375,7 +376,7 @@ class ProductsFilter extends MallComponent
 
         $this->setVar('category', $this->getCategory());
 
-        $categories = collect([$this->category]);
+        $categories = new EloquentCollection([$this->category]);
 
         if ($this->includeChildren) {
             $categories = $this->category->getAllChildrenAndSelf();


### PR DESCRIPTION
When using the `[productsFilter]` component with the `includeChildren` set to false, this error occurs:

```
OFFLINE\Mall\Models\UniquePropertyValue::hydratePropertyValuesForCategories(): Argument #1 ($categories) must be of type Illuminate\Database\Eloquent\Collection, October\Rain\Support\Collection given, called in /app/plugins/offline/mall/models/Property.php on line 132
```

This PR addresses that by creating a new Eloquent Collection instead of using the `collect()` function which creates a `October\Rain\Support\Collection`

