### PR TITLE
fix: preserve current path on filter

### DIFF
--- a/components/productsfilter/scripts.htm
+++ b/components/productsfilter/scripts.htm
@@ -43,7 +43,7 @@
                         var data = response.hasOwnProperty('responseJSON') ? response.reponseJSON : response
 
                         if (data.hasOwnProperty('queryString')) {
-                            history.replaceState(null, '', '?' + data.queryString)
+                            history.replaceState(null, '', window.location.pathname + '?' + data.queryString);
                         }
 
                         $('[data-filter]').hide()


### PR DESCRIPTION
I noticed when filtering, the path was lost. So when I'm on a page with the url `/assortiment/clothing` and filter, the url gets updated to `/?0=on&sort=bestseller`. 
This change fixes that by preserving the current path name