### PR TITLE
Return quantities onUpdateQuantity

### DIFF
--- a/components/Cart.php
+++ b/components/Cart.php
@@ -183,7 +183,7 @@ class Cart extends MallComponent
     /**
      * The user updated the quantity of a specific cart item.
      *
-     * @return void
+     * @return array
      */
     public function onUpdateQuantity()
     {
@@ -193,7 +193,7 @@ class Cart extends MallComponent
         $product = $this->getProductFromCart($cart, $id);
 
         if (!$product) {
-            return;
+            return [];
         }
 
         try {
@@ -201,9 +201,16 @@ class Cart extends MallComponent
         } catch (OutOfStockException $exc) {
             Flash::error(trans('offline.mall::lang.common.out_of_stock', ['quantity' => $exc->product->stock]));
 
-            return;
+            return [];
         } finally {
             $this->setData();
+
+            return [
+                'item' => $this->dataLayerArray($product->product, $product->variant),
+                'quantity' => optional($product)->quantity ?? 0,
+                'new_items_count' => optional($this->cart->products)->count() ?? 0,
+                'new_items_quantity' => optional($this->cart->products)->sum('quantity') ?? 0,
+            ];
         }
     }
 


### PR DESCRIPTION
The docs [show an example](https://offline-gmbh.github.io/oc-mall-plugin/guide/components/cart.html#example-implementations) of having a cart counter. At the moment, it's not possible to update the total quantity when changing the amount in the cart, because this data is not returned by the ajax handler.

This PR fixes that by returning the same data as `onUpdateQuantity` does in the cart component.

The event listener to update the cart quantity would then look like this:
```js
$(function () {
    var $count = $('.js-count');
    $.subscribe('mall.cart.update', function (e, data) {
        // You have access to different values here.
        // console.log(data.item); // All item data
        // console.log(data.quantity); // Added quantity
        // console.log(data.new_items_count); // New total items in cart
        // console.log(data.new_items_quantity); // New total quantity of items in cart
        $count.text(data.new_items_count);
        // /* or */ $count.text(data.new_items_quantity);
    });
});
```