### PR TITLE
Use static instead of self in the default sign up handler

### DIFF
--- a/classes/customer/DefaultSignUpHandler.php
+++ b/classes/customer/DefaultSignUpHandler.php
@@ -185,13 +185,13 @@ class DefaultSignUpHandler implements SignUpHandler
      */
     protected function validate(array $data)
     {
-        $rules = self::rules();
+        $rules = static::rules();
 
         if ($this->asGuest) {
             unset($rules['password'], $rules['password_repeat']);
         }
 
-        $messages = self::messages();
+        $messages = static::messages();
 
         $validation = Validator::make($data, $rules, $messages);
 


### PR DESCRIPTION
I wanted to create a custom signup handler to add some rules like this:
```php

class SignUpHandlerWithPhoneNumber extends DefaultSignUpHandler {

    public static function rules($forSignup = true): array
    {
        $rules = parent::rules($forSignup);

        $rules['phone_number'] = ['required', 'string', 'max:32'];

        return $rules;
    }

    protected function createUser($data, $requiresConfirmation)
    {
        $user = parent::createUser($data, $requiresConfirmation);

        $user->phone_number = $data['phone_number'];
        $user->save();

        return $user;
    }
}
```

However, since the `DefaultSignUpHandler` is calling the `rules` method using `self` it's calling the original method. Calling the method with `static` fixes that and allows me to extend the `DefaultSignUpHandler` and only override the rules method.