### PR TITLE
Filter Brands by only Published Products in ProductFilter Component

### DIFF
--- a/components/ProductsFilter.php
+++ b/components/ProductsFilter.php
@@ -439,6 +439,7 @@ class ProductsFilter extends MallComponent
     protected function setBrands()
     {
         $brands = DB::table('offline_mall_products')
+            ->where('offline_mall_products.published', '=', true)
             ->whereIn('offline_mall_category_product.category_id', $this->categories->pluck('id'))
             ->select('offline_mall_brands.*')
             ->distinct()


### PR DESCRIPTION
### Summary
This Pull Request adds a filter to the `setBrands()` method in the `ProductFilter` component to ensure that only **brands associated with published products** are fetched. This prevents brands linked to unpublished products from being displayed, which is more in line with typical frontend visibility requirements.

### Changes Made
- Added a `where('offline_mall_products.published', true)` condition in the `setBrands()` function to filter only **published products**.
- Updated the SQL query within `setBrands()` to only consider products that are published when determining which brands are associated with a given category.

### Reason for Change
Currently, the `setBrands()` method pulls in all brands present in the selected categories, including brands linked to unpublished products. This leads to inconsistent results and possible confusion for end users. Adding this filter ensures that only brands linked to products that are published are displayed, aligning with the expected product visibility.

This follows the same principal as the other product filters that don't show unpublished products options / filters.

### Testing Done
- Manual Testing: Verified that the brands list on the frontend only includes brands associated with published products.
- Checked that the behavior for categories with only unpublished products correctly results in no brands being listed.
- Ensured that all other product filters continue to work as expected.

### Changed
- Before this change, brands would be displayed even if the associated products were unpublished.
- After this change, the brands filter respects the product published status, ensuring a clean and consistent user experience.

