### PR TITLE
Refactor initRelation to Support Flexible Model Extensions

### DIFF
--- a/controllers/Orders.php
+++ b/controllers/Orders.php
@@ -102,7 +102,7 @@ class Orders extends Controller
 
         $order = Order::with('products', 'order_state')->findOrFail($this->params[0]);
 
-        $this->initRelation($order, 'payment_logs');
+        $this->initRelation($order);
 
         $this->vars['order']        = $order;
         $this->vars['money']        = app(Money::class);


### PR DESCRIPTION
Updated the initRelation method by removing the hardcoded 'payment_logs' relation and modifying it to $this->initRelation($order).

This change allows greater flexibility when extending the model, enabling the use of different relations as needed. It ensures a more adaptable and extensible codebase while maintaining compatibility with the existing logic.