### PR TITLE
Use Event that supports priority

### DIFF
--- a/classes/registration/BootExtensions.php
+++ b/classes/registration/BootExtensions.php
@@ -6,7 +6,7 @@ use Backend;
 use Backend\Widgets\Filter;
 use Backend\Widgets\Form;
 use Backend\Widgets\Lists;
-use Illuminate\Support\Facades\Event;
+use Event;
 use October\Rain\Database\Builder;
 use OFFLINE\Mall\Models\Address;
 use OFFLINE\Mall\Models\Customer;


### PR DESCRIPTION
I tried to hide the `customer_groups` side menu item:
https://github.com/OFFLINE-GmbH/oc-mall-plugin/blob/d4da4579011b1ff5591a739b1b9edd88a152f74c/classes/registration/BootExtensions.php#L124-L142

But I noticed that the subscribe priority does not work as described here: https://docs.octobercms.com/3.x/extend/services/event.html#subscribe-using-priority

So the listener below will still execute before the `customer_groups` is added.
```
Event::listen('backend.menu.extendItems', function (NavigationManager $manager) {
    $manager->removeSideMenuItem('RainLab.User', 'user', 'customer_groups');
}, 4);
```

Illuminate's Event does not implement any priority, so using October's Event fixes this issue.