### PR TITLE
Add config flag to enable or disable failed payment logging

### DIFF
--- a/config/features.php
+++ b/config/features.php
@@ -2,4 +2,7 @@
 return [
     // Display order note textarea in the backend.
     'order_notes' => true,
+
+    // Enable or disable event logging for failed payments (enabled by default)
+    'log_failed_payments' => true,
 ];


### PR DESCRIPTION
Introduced a new `log_failed_payments` boolean flag in `config/features.php`.

This flag controls whether failed payment attempts in the PaymentResult class should be logged. Default is `true` to preserve existing behavior.