### PR TITLE
Update version.yaml

### DIFF
--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -674,4 +674,4 @@ v3.6.12:
 v3.6.13:
     - "Added feature flag to disable logging of failed payments (thanks to @chocolata)"
 v3.6.14:
-    - "Set App locale in Mailer jobs (thanks to @Pindagus)
+    - "Set App locale in Mailer jobs (thanks to @Pindagus)"


### PR DESCRIPTION
Migrating the latest version creates the following error:
```
In Yaml.php line 43:

  A syntax error was detected in /app/plugins/offline/mall/updates/version.yaml. Malformed inline YAML string at
  line 678 at line 43 (near "/app/vendor/october/rain/src/Parse/Yaml.php").
```

This PR fixes that issue.