### PR TITLE
Filter options

### DIFF
--- a/models/Property.php
+++ b/models/Property.php
@@ -143,7 +143,7 @@ class Property extends Model
                 return $values;
             }
 
-            $order = collect($firstProp->options)->flatten()->flip();
+            $order = collect($firstProp->options)->flatten()->filter()->flip();
 
             return $values->sortBy(fn ($value) => $order[$value->value] ?? 0);
         });


### PR DESCRIPTION
When (programmatically) adding an empty (null) option to a Property, an error can occur:
![image](https://github.com/user-attachments/assets/72bd0884-128b-4fe6-b47c-aae55068e6e8)

While it won't happen for users that just use the UI, this fix may help developers that add products from external systems.
