### PR TITLE
Fix product page title fallback when meta_title is empty

### DIFF
--- a/components/Product.php
+++ b/components/Product.php
@@ -204,7 +204,7 @@ class Product extends MallComponent
             return $this->controller->run('404');
         }
 
-        $this->page->title = $this->item->meta_title ?? $this->item->name;
+        $this->page->title = $this->item->meta_title ?: $this->item->name;
         $this->page->meta_description = $this->item->meta_description;
     }
 


### PR DESCRIPTION
Replaced null coalescing operator (??) with ternary (?:) to ensure that an empty meta_title string falls back to item name. Prevents missing <title> tags when meta_title is set but empty.