### PR TITLE
Prevent inheriting product id on create

### DIFF
--- a/models/Variant.php
+++ b/models/Variant.php
@@ -260,7 +260,7 @@ class Variant extends Model
         }
 
         // If any of the product relation columns are called don't override the method's default behaviour.
-        $dontInheritAttribute = \in_array($attribute, ['product', 'product_id', 'all_property_values']);
+        $dontInheritAttribute = \in_array($attribute, ['id', 'product', 'product_id', 'all_property_values']);
 
         if ($dontInheritAttribute || $inheritanceDisabled || ! $this->product_id || ! $this->product) {
             return $originalValue;


### PR DESCRIPTION
Prevents a new Variant from inheriting an existing Product id on create

Example of issue: `(new OFFLINE\Mall\Models\Variant(['product_id' => 1337]))->id` outputs `1337` if this is an existing product id
