### PR TITLE
Remove unnecessary slashes

### DIFF
--- a/controllers/categories/config_relation.yaml
+++ b/controllers/categories/config_relation.yaml
@@ -8,7 +8,7 @@ property_groups:
     view:
         list: $/offline/mall/models/propertygroup/columns_pivot.yaml
         toolbarButtons: add|remove
-        recordUrl: '/offline/mall/propertygroups/update/:id'
+        recordUrl: 'offline/mall/propertygroups/update/:id'
         defaultSort:
             column: pivot[relation_sort_order]
             direction: asc


### PR DESCRIPTION
An unnecessary slash in the `$recordUrl` property causes an issue (404 not found) with latest WinterCMS.