### PR TITLE
Make updates compatible with Laravel 11 changes

### DIFF
--- a/updates/005_01-use_text_columns_for_variant_names.php
+++ b/updates/005_01-use_text_columns_for_variant_names.php
@@ -10,7 +10,7 @@ class UseTextColumnsForVariantNames extends Migration
     public function up()
     {
         Schema::table('offline_mall_order_products', function ($table) {
-            $table->text('variant_name')->change();
+            $table->text('variant_name')->nullable()->change();
         });
     }
 

--- a/updates/006_01-use_text_columns_for_payment_log.php
+++ b/updates/006_01-use_text_columns_for_payment_log.php
@@ -10,8 +10,8 @@ class UseTextColumnsForPaymentLog extends Migration
     public function up()
     {
         Schema::table('offline_mall_payments_log', function ($table) {
-            $table->text('payment_method')->change();
-            $table->text('message')->change();
+            $table->text('payment_method')->nullable()->change();
+            $table->text('message')->nullable()->change();
         });
     }
 

--- a/updates/007_01-update_jsonable_columns_to_mediumtext.php
+++ b/updates/007_01-update_jsonable_columns_to_mediumtext.php
@@ -11,21 +11,21 @@ class UpdateJsonableColumnsToMediumtext extends Migration
     public function up()
     {
         Schema::table('offline_mall_payments_log', function (Blueprint $table) {
-            $table->mediumText('payment_method')->change();
-            $table->mediumText('data')->change();
-            $table->longText('order_data')->change();
+            $table->mediumText('payment_method')->nullable()->change();
+            $table->mediumText('data')->nullable()->change();
+            $table->longText('order_data')->nullable()->change();
         });
         Schema::table('offline_mall_orders', function (Blueprint $table) {
-            $table->mediumText('currency')->change();
-            $table->mediumText('billing_address')->change();
-            $table->mediumText('shipping_address')->change();
-            $table->mediumText('shipping')->change();
-            $table->mediumText('taxes')->change();
-            $table->mediumText('payment')->change();
-            $table->mediumText('payment_data')->change();
+            $table->mediumText('currency')->nullable()->change();
+            $table->mediumText('billing_address')->nullable()->change();
+            $table->mediumText('shipping_address')->nullable()->change();
+            $table->mediumText('shipping')->nullable()->change();
+            $table->mediumText('taxes')->nullable()->change();
+            $table->mediumText('payment')->nullable()->change();
+            $table->mediumText('payment_data')->nullable()->change();
         });
         Schema::table('offline_mall_order_products', function (Blueprint $table) {
-            $table->mediumText('property_values')->change();
+            $table->mediumText('property_values')->nullable()->change();
             $table->longText('custom_field_values')->change();
             $table->mediumText('taxes')->change();
             $table->mediumText('item')->change();

--- a/updates/021_01-update_description_short_column_of_products_table.php
+++ b/updates/021_01-update_description_short_column_of_products_table.php
@@ -10,14 +10,14 @@ class UpdateDescriptionShortColumnOfProductsTable extends Migration
     public function up()
     {
         Schema::table('offline_mall_products', function ($table) {
-            $table->text('description_short')->change();
+            $table->text('description_short')->nullable()->change();
         });
     }
 
     public function down()
     {
         Schema::table('offline_mall_products', function ($table) {
-            $table->string('description_short', 255)->change();
+            $table->string('description_short', 255)->nullable()->change();
         });
     }
 }

--- a/updates/021_02-update_description_short_column_of_product_variants_table.php
+++ b/updates/021_02-update_description_short_column_of_product_variants_table.php
@@ -10,14 +10,14 @@ class UpdateDescriptionShortColumnOfProductVariantsTable extends Migration
     public function up()
     {
         Schema::table('offline_mall_product_variants', function ($table) {
-            $table->text('description_short')->change();
+            $table->text('description_short')->nullable()->change();
         });
     }
 
     public function down()
     {
         Schema::table('offline_mall_product_variants', function ($table) {
-            $table->string('description_short', 255)->change();
+            $table->string('description_short', 255)->nullable()->change();
         });
     }
 }


### PR DESCRIPTION
Was having some problems with the plugin updates in a clean OctoberCMS v4 installation. These changes make the updates compatible with https://laravel.com/docs/11.x/upgrade#modifying-columns