### PR TITLE
Rename type 'mall-all-products' to 'all-mall-products'

### DIFF
--- a/models/Product.php
+++ b/models/Product.php
@@ -697,7 +697,7 @@ class Product extends Model
 
         $result = null;
 
-        if ($type === 'mall-all-products') {
+        if ($type === 'all-mall-products') {
             $data = self::published()->where('inventory_management_method', 'single')->get();
 
             return [


### PR DESCRIPTION
Summary
Sitemap generation for products fails due to a typo in the type checking logic, causing all product URLs to resolve incorrectly.

Description
When using RainLab.Sitemap with OFFLINE.Mall's "All shop products" dynamic item type, the sitemap generates incorrect URLs (all pointing to the same page) instead of individual product URLs.

Root Cause
There is an inconsistency in the type name used throughout the codebase:

In plugins/offline/mall/classes/registration/BootEvents.php:
- Line 54: Type registered as 'all-mall-products'
- Line 85: Type passed to resolveItem as 'all-mall-products'

In plugins/offline/mall/models/Product.php:
- Line 700: Condition checks for 'mall-all-products’ (wrong order)