### PR TITLE
fix: correctly apply discount rate by removing division by 100 from calculation.

### DIFF
--- a/classes/cart/DiscountApplier.php
+++ b/classes/cart/DiscountApplier.php
@@ -75,7 +75,7 @@ class DiscountApplier
         }
 
         if ($discount->type === 'rate') {
-            $savings            = $this->total * ($discount->rate / 100);
+            $savings            = $this->total * $discount->rate;
             $this->reducedTotal -= $savings;
         }
 


### PR DESCRIPTION
I removed the division by 100 in the rate discount calculation because the total is already expressed in base currency units, not cents. Dividing by 100 caused the calculated savings to be incorrect when the discount type is `rate`, resulting in a much smaller discount than intended.