### PR TITLE
Fix: Add missing notification state check for customerCreated method

### DIFF
--- a/classes/events/MailingEventHandler.php
+++ b/classes/events/MailingEventHandler.php
@@ -77,8 +77,8 @@ class MailingEventHandler
      */
     public function customerCreated($handler, $user)
     {
-        // Don't mail guest accounts.
-        if ($user->customer->is_guest) {
+        // Don't send the mail when customer signs up as a guest or when this notification is disabled.
+        if ($user->customer->is_guest || ! $this->enabledNotifications->has('offline.mall::customer.created')) {
             return;
         }
 


### PR DESCRIPTION
This adds a check for notification setting state when new customer is created like the other methods do. Without this check in place when the notification is disabled in backend plugin settings _Error: InvalidArgumentException: Invalid view._ is thrown and the customer gets stuck at the sign in step during checkout with the error being displayed via flash message when submitting the form.