### PR TITLE
fix: resolve all product menu items needs to be an array

### DIFF
--- a/models/Product.php
+++ b/models/Product.php
@@ -707,7 +707,7 @@ class Product extends Model
             $data = self::published()->where('inventory_management_method', 'single')->get();
 
             return [
-                'items' => $data->map($toItem),
+                'items' => $data->map($toItem)->toArray(),
             ];
         } elseif ($type === 'mall-variant') {
             $result = Variant::published()->find($item->reference);


### PR DESCRIPTION
Fixed generating "all-mall-products" menu items for "cms.pageLookup.resolveItem" Event.

The reason it didnt worked is the `is_array` condition here https://github.com/octobercms/october/blob/9ae14dabf82c8cffcd3cff3a92e1381887a228c9/modules/cms/models/PageLookupItem.php#L400

